### PR TITLE
Fix build issues in PR #8

### DIFF
--- a/app/api/blueprints/accounts.py
+++ b/app/api/blueprints/accounts.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    accounts_id    
+    accounts_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.accounts import Accounts
 
 non_id_columns = ['name',
-	'account_number',
-	'iban',
-	'bic',
-	'description']
+    'account_number',
+    'iban',
+    'bic',
+    'description']
 
 accounts_bp = Blueprint('accounts',
     __name__,
@@ -31,7 +31,7 @@ accounts_bp = Blueprint('accounts',
 def get_accounts(accounts_id):
     """
     Logic to get accounts data
-    
+
     Parameter:
     accounts_id (int): Id of the accounts-object
 
@@ -55,20 +55,20 @@ def create_accounts():
             otherwise an error message
     """
     result = Accounts.create(name=request.values.get('name'),
-		account_number=request.values.get('account_number'),
-		iban=request.values.get('iban'),
-		bic=request.values.get('bic'),
-		description=request.values.get('description'))
+        account_number=request.values.get('account_number'),
+        iban=request.values.get('iban'),
+        bic=request.values.get('bic'),
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @accounts_bp.route('/<int:accounts_id>', methods=['PUT'])
 @jwt_required()
 def update_accounts(accounts_id):
     """
     Logic to update accounts data
-    
+
     Parameter:
         accounts_id (int): Id of the accounts-object
 
@@ -81,14 +81,14 @@ def update_accounts(accounts_id):
     result = Accounts.update(accounts_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @accounts_bp.route('/<int:accounts_id>', methods=['DELETE'])
 @jwt_required()
 def delete_accounts(accounts_id):
     """
     Logic to delete accounts data
-    
+
     Parameter:
         accounts_id (int): Id of the accounts-object
 
@@ -99,4 +99,4 @@ def delete_accounts(accounts_id):
     result = Accounts.delete(accounts_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/allergens.py
+++ b/app/api/blueprints/allergens.py
@@ -10,15 +10,15 @@ Functions:
 
 Misc variables:
 
-    allergens_id    
+    allergens_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.allergens import Allergens
 
 non_id_columns = ['code',
-	'name',
-	'description']
+    'name',
+    'description']
 
 allergens_bp = Blueprint('allergens',
     __name__,
@@ -29,7 +29,7 @@ allergens_bp = Blueprint('allergens',
 def get_allergens(allergens_id):
     """
     Logic to get allergens data
-    
+
     Parameter:
     allergens_id (int): Id of the allergens-object
 
@@ -53,18 +53,18 @@ def create_allergens():
             otherwise an error message
     """
     result = Allergens.create(code=request.values.get('code'),
-		name=request.values.get('name'),
-		description=request.values.get('description'))
+        name=request.values.get('name'),
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @allergens_bp.route('/<int:allergens_id>', methods=['PUT'])
 @jwt_required()
 def update_allergens(allergens_id):
     """
     Logic to update allergens data
-    
+
     Parameter:
         allergens_id (int): Id of the allergens-object
 
@@ -77,14 +77,14 @@ def update_allergens(allergens_id):
     result = Allergens.update(allergens_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @allergens_bp.route('/<int:allergens_id>', methods=['DELETE'])
 @jwt_required()
 def delete_allergens(allergens_id):
     """
     Logic to delete allergens data
-    
+
     Parameter:
         allergens_id (int): Id of the allergens-object
 
@@ -95,4 +95,4 @@ def delete_allergens(allergens_id):
     result = Allergens.delete(allergens_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/branch_opening_hours.py
+++ b/app/api/blueprints/branch_opening_hours.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    branch_opening_hours_id    
+    branch_opening_hours_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.branch_opening_hours import Branch_opening_hours
 
 non_id_columns = ['branch_id',
-	'weekday',
-	'opens',
-	'closes']
+    'weekday',
+    'opens',
+    'closes']
 
 branch_opening_hours_bp = Blueprint('branch_opening_hours',
     __name__,
@@ -30,7 +30,7 @@ branch_opening_hours_bp = Blueprint('branch_opening_hours',
 def get_branch_opening_hours(branch_opening_hours_id):
     """
     Logic to get branch_opening_hours data
-    
+
     Parameter:
     branch_opening_hours_id (int): Id of the branch_opening_hours-object
 
@@ -54,19 +54,19 @@ def create_branch_opening_hours():
             otherwise an error message
     """
     result = Branch_opening_hours.create(branch_id=request.values.get('branch_id'),
-		weekday=request.values.get('weekday'),
-		opens=request.values.get('opens'),
-		closes=request.values.get('closes'))
+        weekday=request.values.get('weekday'),
+        opens=request.values.get('opens'),
+        closes=request.values.get('closes'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branch_opening_hours_bp.route('/<int:branch_opening_hours_id>', methods=['PUT'])
 @jwt_required()
 def update_branch_opening_hours(branch_opening_hours_id):
     """
     Logic to update branch_opening_hours data
-    
+
     Parameter:
         branch_opening_hours_id (int): Id of the branch_opening_hours-object
 
@@ -79,14 +79,14 @@ def update_branch_opening_hours(branch_opening_hours_id):
     result = Branch_opening_hours.update(branch_opening_hours_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branch_opening_hours_bp.route('/<int:branch_opening_hours_id>', methods=['DELETE'])
 @jwt_required()
 def delete_branch_opening_hours(branch_opening_hours_id):
     """
     Logic to delete branch_opening_hours data
-    
+
     Parameter:
         branch_opening_hours_id (int): Id of the branch_opening_hours-object
 
@@ -97,4 +97,4 @@ def delete_branch_opening_hours(branch_opening_hours_id):
     result = Branch_opening_hours.delete(branch_opening_hours_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/branch_order_window.py
+++ b/app/api/blueprints/branch_order_window.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    branch_order_window_id    
+    branch_order_window_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.branch_order_window import Branch_order_window
 
 non_id_columns = ['branch_id',
-	'weekday',
-	'order_start',
-	'order_end']
+    'weekday',
+    'order_start',
+    'order_end']
 
 branch_order_window_bp = Blueprint('branch_order_window',
     __name__,
@@ -30,7 +30,7 @@ branch_order_window_bp = Blueprint('branch_order_window',
 def get_branch_order_window(branch_order_window_id):
     """
     Logic to get branch_order_window data
-    
+
     Parameter:
     branch_order_window_id (int): Id of the branch_order_window-object
 
@@ -54,19 +54,19 @@ def create_branch_order_window():
             otherwise an error message
     """
     result = Branch_order_window.create(branch_id=request.values.get('branch_id'),
-		weekday=request.values.get('weekday'),
-		order_start=request.values.get('order_start'),
-		order_end=request.values.get('order_end'))
+        weekday=request.values.get('weekday'),
+        order_start=request.values.get('order_start'),
+        order_end=request.values.get('order_end'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branch_order_window_bp.route('/<int:branch_order_window_id>', methods=['PUT'])
 @jwt_required()
 def update_branch_order_window(branch_order_window_id):
     """
     Logic to update branch_order_window data
-    
+
     Parameter:
         branch_order_window_id (int): Id of the branch_order_window-object
 
@@ -79,14 +79,14 @@ def update_branch_order_window(branch_order_window_id):
     result = Branch_order_window.update(branch_order_window_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branch_order_window_bp.route('/<int:branch_order_window_id>', methods=['DELETE'])
 @jwt_required()
 def delete_branch_order_window(branch_order_window_id):
     """
     Logic to delete branch_order_window data
-    
+
     Parameter:
         branch_order_window_id (int): Id of the branch_order_window-object
 
@@ -97,4 +97,4 @@ def delete_branch_order_window(branch_order_window_id):
     result = Branch_order_window.delete(branch_order_window_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/branches.py
+++ b/app/api/blueprints/branches.py
@@ -10,22 +10,22 @@ Functions:
 
 Misc variables:
 
-    branches_id    
+    branches_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.branches import Branches
 
 non_id_columns = ['name',
-	'address_line',
-	'postal_code',
-	'city',
-	'country',
-	'phone',
-	'email',
-	'opening_note',
-	'created_at',
-	'updated_at']
+    'address_line',
+    'postal_code',
+    'city',
+    'country',
+    'phone',
+    'email',
+    'opening_note',
+    'created_at',
+    'updated_at']
 
 branches_bp = Blueprint('branches',
     __name__,
@@ -36,7 +36,7 @@ branches_bp = Blueprint('branches',
 def get_branches(branches_id):
     """
     Logic to get branches data
-    
+
     Parameter:
     branches_id (int): Id of the branches-object
 
@@ -60,25 +60,25 @@ def create_branches():
             otherwise an error message
     """
     result = Branches.create(name=request.values.get('name'),
-		address_line=request.values.get('address_line'),
-		postal_code=request.values.get('postal_code'),
-		city=request.values.get('city'),
-		country=request.values.get('country'),
-		phone=request.values.get('phone'),
-		email=request.values.get('email'),
-		opening_note=request.values.get('opening_note'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        address_line=request.values.get('address_line'),
+        postal_code=request.values.get('postal_code'),
+        city=request.values.get('city'),
+        country=request.values.get('country'),
+        phone=request.values.get('phone'),
+        email=request.values.get('email'),
+        opening_note=request.values.get('opening_note'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branches_bp.route('/<int:branches_id>', methods=['PUT'])
 @jwt_required()
 def update_branches(branches_id):
     """
     Logic to update branches data
-    
+
     Parameter:
         branches_id (int): Id of the branches-object
 
@@ -91,14 +91,14 @@ def update_branches(branches_id):
     result = Branches.update(branches_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @branches_bp.route('/<int:branches_id>', methods=['DELETE'])
 @jwt_required()
 def delete_branches(branches_id):
     """
     Logic to delete branches data
-    
+
     Parameter:
         branches_id (int): Id of the branches-object
 
@@ -109,4 +109,4 @@ def delete_branches(branches_id):
     result = Branches.delete(branches_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/complaints.py
+++ b/app/api/blueprints/complaints.py
@@ -10,19 +10,19 @@ Functions:
 
 Misc variables:
 
-    complaints_id    
+    complaints_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.complaints import Complaints
 
 non_id_columns = ['customer_id',
-	'order_id',
-	'product_id',
-	'description',
-	'resolved',
-	'created_at',
-	'resolved_at']
+    'order_id',
+    'product_id',
+    'description',
+    'resolved',
+    'created_at',
+    'resolved_at']
 
 complaints_bp = Blueprint('complaints',
     __name__,
@@ -33,7 +33,7 @@ complaints_bp = Blueprint('complaints',
 def get_complaints(complaints_id):
     """
     Logic to get complaints data
-    
+
     Parameter:
     complaints_id (int): Id of the complaints-object
 
@@ -57,22 +57,22 @@ def create_complaints():
             otherwise an error message
     """
     result = Complaints.create(customer_id=request.values.get('customer_id'),
-		order_id=request.values.get('order_id'),
-		product_id=request.values.get('product_id'),
-		description=request.values.get('description'),
-		resolved=request.values.get('resolved'),
-		created_at=request.values.get('created_at'),
-		resolved_at=request.values.get('resolved_at'))
+        order_id=request.values.get('order_id'),
+        product_id=request.values.get('product_id'),
+        description=request.values.get('description'),
+        resolved=request.values.get('resolved'),
+        created_at=request.values.get('created_at'),
+        resolved_at=request.values.get('resolved_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @complaints_bp.route('/<int:complaints_id>', methods=['PUT'])
 @jwt_required()
 def update_complaints(complaints_id):
     """
     Logic to update complaints data
-    
+
     Parameter:
         complaints_id (int): Id of the complaints-object
 
@@ -85,14 +85,14 @@ def update_complaints(complaints_id):
     result = Complaints.update(complaints_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @complaints_bp.route('/<int:complaints_id>', methods=['DELETE'])
 @jwt_required()
 def delete_complaints(complaints_id):
     """
     Logic to delete complaints data
-    
+
     Parameter:
         complaints_id (int): Id of the complaints-object
 
@@ -103,4 +103,4 @@ def delete_complaints(complaints_id):
     result = Complaints.delete(complaints_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/customer_feedback.py
+++ b/app/api/blueprints/customer_feedback.py
@@ -10,18 +10,18 @@ Functions:
 
 Misc variables:
 
-    customer_feedback_id    
+    customer_feedback_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.customer_feedback import Customer_feedback
 
 non_id_columns = ['customer_id',
-	'branch_id',
-	'order_id',
-	'rating',
-	'comment',
-	'created_at']
+    'branch_id',
+    'order_id',
+    'rating',
+    'comment',
+    'created_at']
 
 customer_feedback_bp = Blueprint('customer_feedback',
     __name__,
@@ -32,7 +32,7 @@ customer_feedback_bp = Blueprint('customer_feedback',
 def get_customer_feedback(customer_feedback_id):
     """
     Logic to get customer_feedback data
-    
+
     Parameter:
     customer_feedback_id (int): Id of the customer_feedback-object
 
@@ -56,21 +56,21 @@ def create_customer_feedback():
             otherwise an error message
     """
     result = Customer_feedback.create(customer_id=request.values.get('customer_id'),
-		branch_id=request.values.get('branch_id'),
-		order_id=request.values.get('order_id'),
-		rating=request.values.get('rating'),
-		comment=request.values.get('comment'),
-		created_at=request.values.get('created_at'))
+        branch_id=request.values.get('branch_id'),
+        order_id=request.values.get('order_id'),
+        rating=request.values.get('rating'),
+        comment=request.values.get('comment'),
+        created_at=request.values.get('created_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_feedback_bp.route('/<int:customer_feedback_id>', methods=['PUT'])
 @jwt_required()
 def update_customer_feedback(customer_feedback_id):
     """
     Logic to update customer_feedback data
-    
+
     Parameter:
         customer_feedback_id (int): Id of the customer_feedback-object
 
@@ -83,14 +83,14 @@ def update_customer_feedback(customer_feedback_id):
     result = Customer_feedback.update(customer_feedback_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_feedback_bp.route('/<int:customer_feedback_id>', methods=['DELETE'])
 @jwt_required()
 def delete_customer_feedback(customer_feedback_id):
     """
     Logic to delete customer_feedback data
-    
+
     Parameter:
         customer_feedback_id (int): Id of the customer_feedback-object
 
@@ -101,4 +101,4 @@ def delete_customer_feedback(customer_feedback_id):
     result = Customer_feedback.delete(customer_feedback_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/customer_order_items.py
+++ b/app/api/blueprints/customer_order_items.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    customer_order_items_id    
+    customer_order_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.customer_order_items import Customer_order_items
 
 non_id_columns = ['order_id',
-	'product_id',
-	'quantity',
-	'unit_price',
-	'tax_code_id']
+    'product_id',
+    'quantity',
+    'unit_price',
+    'tax_code_id']
 
 customer_order_items_bp = Blueprint('customer_order_items',
     __name__,
@@ -31,7 +31,7 @@ customer_order_items_bp = Blueprint('customer_order_items',
 def get_customer_order_items(customer_order_items_id):
     """
     Logic to get customer_order_items data
-    
+
     Parameter:
     customer_order_items_id (int): Id of the customer_order_items-object
 
@@ -55,20 +55,20 @@ def create_customer_order_items():
             otherwise an error message
     """
     result = Customer_order_items.create(order_id=request.values.get('order_id'),
-		product_id=request.values.get('product_id'),
-		quantity=request.values.get('quantity'),
-		unit_price=request.values.get('unit_price'),
-		tax_code_id=request.values.get('tax_code_id'))
+        product_id=request.values.get('product_id'),
+        quantity=request.values.get('quantity'),
+        unit_price=request.values.get('unit_price'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_order_items_bp.route('/<int:customer_order_items_id>', methods=['PUT'])
 @jwt_required()
 def update_customer_order_items(customer_order_items_id):
     """
     Logic to update customer_order_items data
-    
+
     Parameter:
         customer_order_items_id (int): Id of the customer_order_items-object
 
@@ -81,14 +81,14 @@ def update_customer_order_items(customer_order_items_id):
     result = Customer_order_items.update(customer_order_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_order_items_bp.route('/<int:customer_order_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_customer_order_items(customer_order_items_id):
     """
     Logic to delete customer_order_items data
-    
+
     Parameter:
         customer_order_items_id (int): Id of the customer_order_items-object
 
@@ -99,4 +99,4 @@ def delete_customer_order_items(customer_order_items_id):
     result = Customer_order_items.delete(customer_order_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/customer_orders.py
+++ b/app/api/blueprints/customer_orders.py
@@ -10,24 +10,24 @@ Functions:
 
 Misc variables:
 
-    customer_orders_id    
+    customer_orders_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.customer_orders import Customer_orders
 
 non_id_columns = ['order_number',
-	'customer_id',
-	'customer_name',
-	'branch_id',
-	'order_datetime',
-	'desired_datetime',
-	'serial',
-	'serial_end',
-	'status',
-	'total_amount',
-	'payment_status',
-	'comment']
+    'customer_id',
+    'customer_name',
+    'branch_id',
+    'order_datetime',
+    'desired_datetime',
+    'serial',
+    'serial_end',
+    'status',
+    'total_amount',
+    'payment_status',
+    'comment']
 
 customer_orders_bp = Blueprint('customer_orders',
     __name__,
@@ -38,7 +38,7 @@ customer_orders_bp = Blueprint('customer_orders',
 def get_customer_orders(customer_orders_id):
     """
     Logic to get customer_orders data
-    
+
     Parameter:
     customer_orders_id (int): Id of the customer_orders-object
 
@@ -62,27 +62,27 @@ def create_customer_orders():
             otherwise an error message
     """
     result = Customer_orders.create(order_number=request.values.get('order_number'),
-		customer_id=request.values.get('customer_id'),
-		customer_name=request.values.get('customer_name'),
-		branch_id=request.values.get('branch_id'),
-		order_datetime=request.values.get('order_datetime'),
-		desired_datetime=request.values.get('desired_datetime'),
-		serial=request.values.get('serial'),
-		serial_end=request.values.get('serial_end'),
-		status=request.values.get('status'),
-		total_amount=request.values.get('total_amount'),
-		payment_status=request.values.get('payment_status'),
-		comment=request.values.get('comment'))
+        customer_id=request.values.get('customer_id'),
+        customer_name=request.values.get('customer_name'),
+        branch_id=request.values.get('branch_id'),
+        order_datetime=request.values.get('order_datetime'),
+        desired_datetime=request.values.get('desired_datetime'),
+        serial=request.values.get('serial'),
+        serial_end=request.values.get('serial_end'),
+        status=request.values.get('status'),
+        total_amount=request.values.get('total_amount'),
+        payment_status=request.values.get('payment_status'),
+        comment=request.values.get('comment'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_orders_bp.route('/<int:customer_orders_id>', methods=['PUT'])
 @jwt_required()
 def update_customer_orders(customer_orders_id):
     """
     Logic to update customer_orders data
-    
+
     Parameter:
         customer_orders_id (int): Id of the customer_orders-object
 
@@ -95,14 +95,14 @@ def update_customer_orders(customer_orders_id):
     result = Customer_orders.update(customer_orders_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customer_orders_bp.route('/<int:customer_orders_id>', methods=['DELETE'])
 @jwt_required()
 def delete_customer_orders(customer_orders_id):
     """
     Logic to delete customer_orders data
-    
+
     Parameter:
         customer_orders_id (int): Id of the customer_orders-object
 
@@ -113,4 +113,4 @@ def delete_customer_orders(customer_orders_id):
     result = Customer_orders.delete(customer_orders_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/customers.py
+++ b/app/api/blueprints/customers.py
@@ -10,24 +10,24 @@ Functions:
 
 Misc variables:
 
-    customers_id    
+    customers_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.customers import Customers
 
 non_id_columns = ['type',
-	'company_name',
-	'first_name',
-	'last_name',
-	'email',
-	'phone',
-	'address_line',
-	'postal_code',
-	'city',
-	'country',
-	'created_at',
-	'updated_at']
+    'company_name',
+    'first_name',
+    'last_name',
+    'email',
+    'phone',
+    'address_line',
+    'postal_code',
+    'city',
+    'country',
+    'created_at',
+    'updated_at']
 
 customers_bp = Blueprint('customers',
     __name__,
@@ -38,7 +38,7 @@ customers_bp = Blueprint('customers',
 def get_customers(customers_id):
     """
     Logic to get customers data
-    
+
     Parameter:
     customers_id (int): Id of the customers-object
 
@@ -62,27 +62,27 @@ def create_customers():
             otherwise an error message
     """
     result = Customers.create(type=request.values.get('type'),
-		company_name=request.values.get('company_name'),
-		first_name=request.values.get('first_name'),
-		last_name=request.values.get('last_name'),
-		email=request.values.get('email'),
-		phone=request.values.get('phone'),
-		address_line=request.values.get('address_line'),
-		postal_code=request.values.get('postal_code'),
-		city=request.values.get('city'),
-		country=request.values.get('country'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        company_name=request.values.get('company_name'),
+        first_name=request.values.get('first_name'),
+        last_name=request.values.get('last_name'),
+        email=request.values.get('email'),
+        phone=request.values.get('phone'),
+        address_line=request.values.get('address_line'),
+        postal_code=request.values.get('postal_code'),
+        city=request.values.get('city'),
+        country=request.values.get('country'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customers_bp.route('/<int:customers_id>', methods=['PUT'])
 @jwt_required()
 def update_customers(customers_id):
     """
     Logic to update customers data
-    
+
     Parameter:
         customers_id (int): Id of the customers-object
 
@@ -95,14 +95,14 @@ def update_customers(customers_id):
     result = Customers.update(customers_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @customers_bp.route('/<int:customers_id>', methods=['DELETE'])
 @jwt_required()
 def delete_customers(customers_id):
     """
     Logic to delete customers data
-    
+
     Parameter:
         customers_id (int): Id of the customers-object
 
@@ -113,4 +113,4 @@ def delete_customers(customers_id):
     result = Customers.delete(customers_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/employee_time_entries.py
+++ b/app/api/blueprints/employee_time_entries.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    employee_time_entries_id    
+    employee_time_entries_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.employee_time_entries import Employee_time_entries
 
 non_id_columns = ['employee_id',
-	'branch_id',
-	'clock_in',
-	'clock_out',
-	'break_minutes']
+    'branch_id',
+    'clock_in',
+    'clock_out',
+    'break_minutes']
 
 employee_time_entries_bp = Blueprint('employee_time_entries',
     __name__,
@@ -31,7 +31,7 @@ employee_time_entries_bp = Blueprint('employee_time_entries',
 def get_employee_time_entries(employee_time_entries_id):
     """
     Logic to get employee_time_entries data
-    
+
     Parameter:
     employee_time_entries_id (int): Id of the employee_time_entries-object
 
@@ -55,20 +55,20 @@ def create_employee_time_entries():
             otherwise an error message
     """
     result = Employee_time_entries.create(employee_id=request.values.get('employee_id'),
-		branch_id=request.values.get('branch_id'),
-		clock_in=request.values.get('clock_in'),
-		clock_out=request.values.get('clock_out'),
-		break_minutes=request.values.get('break_minutes'))
+        branch_id=request.values.get('branch_id'),
+        clock_in=request.values.get('clock_in'),
+        clock_out=request.values.get('clock_out'),
+        break_minutes=request.values.get('break_minutes'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @employee_time_entries_bp.route('/<int:employee_time_entries_id>', methods=['PUT'])
 @jwt_required()
 def update_employee_time_entries(employee_time_entries_id):
     """
     Logic to update employee_time_entries data
-    
+
     Parameter:
         employee_time_entries_id (int): Id of the employee_time_entries-object
 
@@ -81,14 +81,14 @@ def update_employee_time_entries(employee_time_entries_id):
     result = Employee_time_entries.update(employee_time_entries_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @employee_time_entries_bp.route('/<int:employee_time_entries_id>', methods=['DELETE'])
 @jwt_required()
 def delete_employee_time_entries(employee_time_entries_id):
     """
     Logic to delete employee_time_entries data
-    
+
     Parameter:
         employee_time_entries_id (int): Id of the employee_time_entries-object
 
@@ -99,4 +99,4 @@ def delete_employee_time_entries(employee_time_entries_id):
     result = Employee_time_entries.delete(employee_time_entries_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/employees.py
+++ b/app/api/blueprints/employees.py
@@ -10,22 +10,22 @@ Functions:
 
 Misc variables:
 
-    employees_id    
+    employees_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.employees import Employees
 
 non_id_columns = ['first_name',
-	'last_name',
-	'email',
-	'phone',
-	'hire_date',
-	'termination_date',
-	'hourly_wage',
-	'monthly_salary',
-	'created_at',
-	'updated_at']
+    'last_name',
+    'email',
+    'phone',
+    'hire_date',
+    'termination_date',
+    'hourly_wage',
+    'monthly_salary',
+    'created_at',
+    'updated_at']
 
 employees_bp = Blueprint('employees',
     __name__,
@@ -36,7 +36,7 @@ employees_bp = Blueprint('employees',
 def get_employees(employees_id):
     """
     Logic to get employees data
-    
+
     Parameter:
     employees_id (int): Id of the employees-object
 
@@ -60,25 +60,25 @@ def create_employees():
             otherwise an error message
     """
     result = Employees.create(first_name=request.values.get('first_name'),
-		last_name=request.values.get('last_name'),
-		email=request.values.get('email'),
-		phone=request.values.get('phone'),
-		hire_date=request.values.get('hire_date'),
-		termination_date=request.values.get('termination_date'),
-		hourly_wage=request.values.get('hourly_wage'),
-		monthly_salary=request.values.get('monthly_salary'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        last_name=request.values.get('last_name'),
+        email=request.values.get('email'),
+        phone=request.values.get('phone'),
+        hire_date=request.values.get('hire_date'),
+        termination_date=request.values.get('termination_date'),
+        hourly_wage=request.values.get('hourly_wage'),
+        monthly_salary=request.values.get('monthly_salary'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @employees_bp.route('/<int:employees_id>', methods=['PUT'])
 @jwt_required()
 def update_employees(employees_id):
     """
     Logic to update employees data
-    
+
     Parameter:
         employees_id (int): Id of the employees-object
 
@@ -91,14 +91,14 @@ def update_employees(employees_id):
     result = Employees.update(employees_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @employees_bp.route('/<int:employees_id>', methods=['DELETE'])
 @jwt_required()
 def delete_employees(employees_id):
     """
     Logic to delete employees data
-    
+
     Parameter:
         employees_id (int): Id of the employees-object
 
@@ -109,4 +109,4 @@ def delete_employees(employees_id):
     result = Employees.delete(employees_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/goods_receipt_items.py
+++ b/app/api/blueprints/goods_receipt_items.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    goods_receipt_items_id    
+    goods_receipt_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.goods_receipt_items import Goods_receipt_items
 
 non_id_columns = ['receipt_id',
-	'ingredient_id',
-	'qty',
-	'unit_price',
-	'tax_code_id']
+    'ingredient_id',
+    'qty',
+    'unit_price',
+    'tax_code_id']
 
 goods_receipt_items_bp = Blueprint('goods_receipt_items',
     __name__,
@@ -31,7 +31,7 @@ goods_receipt_items_bp = Blueprint('goods_receipt_items',
 def get_goods_receipt_items(goods_receipt_items_id):
     """
     Logic to get goods_receipt_items data
-    
+
     Parameter:
     goods_receipt_items_id (int): Id of the goods_receipt_items-object
 
@@ -55,20 +55,20 @@ def create_goods_receipt_items():
             otherwise an error message
     """
     result = Goods_receipt_items.create(receipt_id=request.values.get('receipt_id'),
-		ingredient_id=request.values.get('ingredient_id'),
-		qty=request.values.get('qty'),
-		unit_price=request.values.get('unit_price'),
-		tax_code_id=request.values.get('tax_code_id'))
+        ingredient_id=request.values.get('ingredient_id'),
+        qty=request.values.get('qty'),
+        unit_price=request.values.get('unit_price'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @goods_receipt_items_bp.route('/<int:goods_receipt_items_id>', methods=['PUT'])
 @jwt_required()
 def update_goods_receipt_items(goods_receipt_items_id):
     """
     Logic to update goods_receipt_items data
-    
+
     Parameter:
         goods_receipt_items_id (int): Id of the goods_receipt_items-object
 
@@ -81,14 +81,14 @@ def update_goods_receipt_items(goods_receipt_items_id):
     result = Goods_receipt_items.update(goods_receipt_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @goods_receipt_items_bp.route('/<int:goods_receipt_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_goods_receipt_items(goods_receipt_items_id):
     """
     Logic to delete goods_receipt_items data
-    
+
     Parameter:
         goods_receipt_items_id (int): Id of the goods_receipt_items-object
 
@@ -99,4 +99,4 @@ def delete_goods_receipt_items(goods_receipt_items_id):
     result = Goods_receipt_items.delete(goods_receipt_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/goods_receipts.py
+++ b/app/api/blueprints/goods_receipts.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    goods_receipts_id    
+    goods_receipts_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.goods_receipts import Goods_receipts
 
 non_id_columns = ['receipt_number',
-	'supplier_order_id',
-	'receipt_date',
-	'created_at']
+    'supplier_order_id',
+    'receipt_date',
+    'created_at']
 
 goods_receipts_bp = Blueprint('goods_receipts',
     __name__,
@@ -30,7 +30,7 @@ goods_receipts_bp = Blueprint('goods_receipts',
 def get_goods_receipts(goods_receipts_id):
     """
     Logic to get goods_receipts data
-    
+
     Parameter:
     goods_receipts_id (int): Id of the goods_receipts-object
 
@@ -43,6 +43,7 @@ def get_goods_receipts(goods_receipts_id):
         return jsonify({'success': False, 'error': 'Not found'}), 404
     return jsonify({'success': True, 'data': result}), 200
 
+
 @goods_receipts_bp.route('/', methods=['POST'])
 @jwt_required()
 def create_goods_receipts():
@@ -54,19 +55,20 @@ def create_goods_receipts():
             otherwise an error message
     """
     result = Goods_receipts.create(receipt_number=request.values.get('receipt_number'),
-		supplier_order_id=request.values.get('supplier_order_id'),
-		receipt_date=request.values.get('receipt_date'),
-		created_at=request.values.get('created_at'))
+        supplier_order_id=request.values.get('supplier_order_id'),
+        receipt_date=request.values.get('receipt_date'),
+        created_at=request.values.get('created_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
+
 
 @goods_receipts_bp.route('/<int:goods_receipts_id>', methods=['PUT'])
 @jwt_required()
 def update_goods_receipts(goods_receipts_id):
     """
     Logic to update goods_receipts data
-    
+
     Parameter:
         goods_receipts_id (int): Id of the goods_receipts-object
 
@@ -79,14 +81,15 @@ def update_goods_receipts(goods_receipts_id):
     result = Goods_receipts.update(goods_receipts_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
+
 
 @goods_receipts_bp.route('/<int:goods_receipts_id>', methods=['DELETE'])
 @jwt_required()
 def delete_goods_receipts(goods_receipts_id):
     """
     Logic to delete goods_receipts data
-    
+
     Parameter:
         goods_receipts_id (int): Id of the goods_receipts-object
 
@@ -97,4 +100,4 @@ def delete_goods_receipts(goods_receipts_id):
     result = Goods_receipts.delete(goods_receipts_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/ingredient_allergens.py
+++ b/app/api/blueprints/ingredient_allergens.py
@@ -10,14 +10,14 @@ Functions:
 
 Misc variables:
 
-    ingredient_allergens_id    
+    ingredient_allergens_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.ingredient_allergens import Ingredient_allergens
 
 non_id_columns = ['ingredient_id',
-	'allergen_id']
+    'allergen_id']
 
 ingredient_allergens_bp = Blueprint('ingredient_allergens',
     __name__,
@@ -28,7 +28,7 @@ ingredient_allergens_bp = Blueprint('ingredient_allergens',
 def get_ingredient_allergens(ingredient_allergens_id):
     """
     Logic to get ingredient_allergens data
-    
+
     Parameter:
     ingredient_allergens_id (int): Id of the ingredient_allergens-object
 
@@ -52,17 +52,17 @@ def create_ingredient_allergens():
             otherwise an error message
     """
     result = Ingredient_allergens.create(ingredient_id=request.values.get('ingredient_id'),
-		allergen_id=request.values.get('allergen_id'))
+        allergen_id=request.values.get('allergen_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @ingredient_allergens_bp.route('/<int:ingredient_allergens_id>', methods=['PUT'])
 @jwt_required()
 def update_ingredient_allergens(ingredient_allergens_id):
     """
     Logic to update ingredient_allergens data
-    
+
     Parameter:
         ingredient_allergens_id (int): Id of the ingredient_allergens-object
 
@@ -75,14 +75,14 @@ def update_ingredient_allergens(ingredient_allergens_id):
     result = Ingredient_allergens.update(ingredient_allergens_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @ingredient_allergens_bp.route('/<int:ingredient_allergens_id>', methods=['DELETE'])
 @jwt_required()
 def delete_ingredient_allergens(ingredient_allergens_id):
     """
     Logic to delete ingredient_allergens data
-    
+
     Parameter:
         ingredient_allergens_id (int): Id of the ingredient_allergens-object
 
@@ -93,4 +93,4 @@ def delete_ingredient_allergens(ingredient_allergens_id):
     result = Ingredient_allergens.delete(ingredient_allergens_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/ingredients.py
+++ b/app/api/blueprints/ingredients.py
@@ -10,19 +10,19 @@ Functions:
 
 Misc variables:
 
-    ingredients_id    
+    ingredients_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.ingredients import Ingredients
 
 non_id_columns = ['name',
-	'unit',
-	'purchase_price',
-	'tax_code_id',
-	'is_active',
-	'created_at',
-	'updated_at']
+    'unit',
+    'purchase_price',
+    'tax_code_id',
+    'is_active',
+    'created_at',
+    'updated_at']
 
 ingredients_bp = Blueprint('ingredients',
     __name__,
@@ -33,7 +33,7 @@ ingredients_bp = Blueprint('ingredients',
 def get_ingredients(ingredients_id):
     """
     Logic to get ingredients data
-    
+
     Parameter:
     ingredients_id (int): Id of the ingredients-object
 
@@ -57,22 +57,22 @@ def create_ingredients():
             otherwise an error message
     """
     result = Ingredients.create(name=request.values.get('name'),
-		unit=request.values.get('unit'),
-		purchase_price=request.values.get('purchase_price'),
-		tax_code_id=request.values.get('tax_code_id'),
-		is_active=request.values.get('is_active'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        unit=request.values.get('unit'),
+        purchase_price=request.values.get('purchase_price'),
+        tax_code_id=request.values.get('tax_code_id'),
+        is_active=request.values.get('is_active'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @ingredients_bp.route('/<int:ingredients_id>', methods=['PUT'])
 @jwt_required()
 def update_ingredients(ingredients_id):
     """
     Logic to update ingredients data
-    
+
     Parameter:
         ingredients_id (int): Id of the ingredients-object
 
@@ -85,14 +85,14 @@ def update_ingredients(ingredients_id):
     result = Ingredients.update(ingredients_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @ingredients_bp.route('/<int:ingredients_id>', methods=['DELETE'])
 @jwt_required()
 def delete_ingredients(ingredients_id):
     """
     Logic to delete ingredients data
-    
+
     Parameter:
         ingredients_id (int): Id of the ingredients-object
 
@@ -103,4 +103,4 @@ def delete_ingredients(ingredients_id):
     result = Ingredients.delete(ingredients_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/inventory_locations.py
+++ b/app/api/blueprints/inventory_locations.py
@@ -10,15 +10,15 @@ Functions:
 
 Misc variables:
 
-    inventory_locations_id    
+    inventory_locations_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.inventory_locations import Inventory_locations
 
 non_id_columns = ['warehouse_id',
-	'code',
-	'description']
+    'code',
+    'description']
 
 inventory_locations_bp = Blueprint('inventory_locations',
     __name__,
@@ -29,7 +29,7 @@ inventory_locations_bp = Blueprint('inventory_locations',
 def get_inventory_locations(inventory_locations_id):
     """
     Logic to get inventory_locations data
-    
+
     Parameter:
     inventory_locations_id (int): Id of the inventory_locations-object
 
@@ -53,18 +53,18 @@ def create_inventory_locations():
             otherwise an error message
     """
     result = Inventory_locations.create(warehouse_id=request.values.get('warehouse_id'),
-		code=request.values.get('code'),
-		description=request.values.get('description'))
+        code=request.values.get('code'),
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @inventory_locations_bp.route('/<int:inventory_locations_id>', methods=['PUT'])
 @jwt_required()
 def update_inventory_locations(inventory_locations_id):
     """
     Logic to update inventory_locations data
-    
+
     Parameter:
         inventory_locations_id (int): Id of the inventory_locations-object
 
@@ -77,14 +77,14 @@ def update_inventory_locations(inventory_locations_id):
     result = Inventory_locations.update(inventory_locations_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @inventory_locations_bp.route('/<int:inventory_locations_id>', methods=['DELETE'])
 @jwt_required()
 def delete_inventory_locations(inventory_locations_id):
     """
     Logic to delete inventory_locations data
-    
+
     Parameter:
         inventory_locations_id (int): Id of the inventory_locations-object
 
@@ -95,4 +95,4 @@ def delete_inventory_locations(inventory_locations_id):
     result = Inventory_locations.delete(inventory_locations_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/inventory_movements.py
+++ b/app/api/blueprints/inventory_movements.py
@@ -10,22 +10,22 @@ Functions:
 
 Misc variables:
 
-    inventory_movements_id    
+    inventory_movements_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.inventory_movements import Inventory_movements
 
 non_id_columns = ['movement_type',
-	'ingredient_id',
-	'qty',
-	'unit',
-	'from_location_id',
-	'to_location_id',
-	'reference_type',
-	'reference_id',
-	'created_at',
-	'user_id']
+    'ingredient_id',
+    'qty',
+    'unit',
+    'from_location_id',
+    'to_location_id',
+    'reference_type',
+    'reference_id',
+    'created_at',
+    'user_id']
 
 inventory_movements_bp = Blueprint('inventory_movements',
     __name__,
@@ -36,7 +36,7 @@ inventory_movements_bp = Blueprint('inventory_movements',
 def get_inventory_movements(inventory_movements_id):
     """
     Logic to get inventory_movements data
-    
+
     Parameter:
     inventory_movements_id (int): Id of the inventory_movements-object
 
@@ -60,25 +60,25 @@ def create_inventory_movements():
             otherwise an error message
     """
     result = Inventory_movements.create(movement_type=request.values.get('movement_type'),
-		ingredient_id=request.values.get('ingredient_id'),
-		qty=request.values.get('qty'),
-		unit=request.values.get('unit'),
-		from_location_id=request.values.get('from_location_id'),
-		to_location_id=request.values.get('to_location_id'),
-		reference_type=request.values.get('reference_type'),
-		reference_id=request.values.get('reference_id'),
-		created_at=request.values.get('created_at'),
-		user_id=request.values.get('user_id'))
+        ingredient_id=request.values.get('ingredient_id'),
+        qty=request.values.get('qty'),
+        unit=request.values.get('unit'),
+        from_location_id=request.values.get('from_location_id'),
+        to_location_id=request.values.get('to_location_id'),
+        reference_type=request.values.get('reference_type'),
+        reference_id=request.values.get('reference_id'),
+        created_at=request.values.get('created_at'),
+        user_id=request.values.get('user_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @inventory_movements_bp.route('/<int:inventory_movements_id>', methods=['PUT'])
 @jwt_required()
 def update_inventory_movements(inventory_movements_id):
     """
     Logic to update inventory_movements data
-    
+
     Parameter:
         inventory_movements_id (int): Id of the inventory_movements-object
 
@@ -91,14 +91,14 @@ def update_inventory_movements(inventory_movements_id):
     result = Inventory_movements.update(inventory_movements_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @inventory_movements_bp.route('/<int:inventory_movements_id>', methods=['DELETE'])
 @jwt_required()
 def delete_inventory_movements(inventory_movements_id):
     """
     Logic to delete inventory_movements data
-    
+
     Parameter:
         inventory_movements_id (int): Id of the inventory_movements-object
 
@@ -109,4 +109,4 @@ def delete_inventory_movements(inventory_movements_id):
     result = Inventory_movements.delete(inventory_movements_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/machines.py
+++ b/app/api/blueprints/machines.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    machines_id    
+    machines_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.machines import Machines
 
 non_id_columns = ['branch_id',
-	'name',
-	'serial_number',
-	'purchase_date',
-	'last_maintenance']
+    'name',
+    'serial_number',
+    'purchase_date',
+    'last_maintenance']
 
 machines_bp = Blueprint('machines',
     __name__,
@@ -31,7 +31,7 @@ machines_bp = Blueprint('machines',
 def get_machines(machines_id):
     """
     Logic to get machines data
-    
+
     Parameter:
     machines_id (int): Id of the machines-object
 
@@ -55,20 +55,20 @@ def create_machines():
             otherwise an error message
     """
     result = Machines.create(branch_id=request.values.get('branch_id'),
-		name=request.values.get('name'),
-		serial_number=request.values.get('serial_number'),
-		purchase_date=request.values.get('purchase_date'),
-		last_maintenance=request.values.get('last_maintenance'))
+        name=request.values.get('name'),
+        serial_number=request.values.get('serial_number'),
+        purchase_date=request.values.get('purchase_date'),
+        last_maintenance=request.values.get('last_maintenance'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @machines_bp.route('/<int:machines_id>', methods=['PUT'])
 @jwt_required()
 def update_machines(machines_id):
     """
     Logic to update machines data
-    
+
     Parameter:
         machines_id (int): Id of the machines-object
 
@@ -81,14 +81,14 @@ def update_machines(machines_id):
     result = Machines.update(machines_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @machines_bp.route('/<int:machines_id>', methods=['DELETE'])
 @jwt_required()
 def delete_machines(machines_id):
     """
     Logic to delete machines data
-    
+
     Parameter:
         machines_id (int): Id of the machines-object
 
@@ -99,4 +99,4 @@ def delete_machines(machines_id):
     result = Machines.delete(machines_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/payment_methods.py
+++ b/app/api/blueprints/payment_methods.py
@@ -10,15 +10,15 @@ Functions:
 
 Misc variables:
 
-    payment_methods_id    
+    payment_methods_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.payment_methods import Payment_methods
 
 non_id_columns = ['name',
-	'external_code',
-	'is_cash']
+    'external_code',
+    'is_cash']
 
 payment_methods_bp = Blueprint('payment_methods',
     __name__,
@@ -29,7 +29,7 @@ payment_methods_bp = Blueprint('payment_methods',
 def get_payment_methods(payment_methods_id):
     """
     Logic to get payment_methods data
-    
+
     Parameter:
     payment_methods_id (int): Id of the payment_methods-object
 
@@ -53,18 +53,18 @@ def create_payment_methods():
             otherwise an error message
     """
     result = Payment_methods.create(name=request.values.get('name'),
-		external_code=request.values.get('external_code'),
-		is_cash=request.values.get('is_cash'))
+        external_code=request.values.get('external_code'),
+        is_cash=request.values.get('is_cash'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @payment_methods_bp.route('/<int:payment_methods_id>', methods=['PUT'])
 @jwt_required()
 def update_payment_methods(payment_methods_id):
     """
     Logic to update payment_methods data
-    
+
     Parameter:
         payment_methods_id (int): Id of the payment_methods-object
 
@@ -77,14 +77,14 @@ def update_payment_methods(payment_methods_id):
     result = Payment_methods.update(payment_methods_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @payment_methods_bp.route('/<int:payment_methods_id>', methods=['DELETE'])
 @jwt_required()
 def delete_payment_methods(payment_methods_id):
     """
     Logic to delete payment_methods data
-    
+
     Parameter:
         payment_methods_id (int): Id of the payment_methods-object
 
@@ -95,4 +95,4 @@ def delete_payment_methods(payment_methods_id):
     result = Payment_methods.delete(payment_methods_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/payment_transactions.py
+++ b/app/api/blueprints/payment_transactions.py
@@ -10,21 +10,21 @@ Functions:
 
 Misc variables:
 
-    payment_transactions_id    
+    payment_transactions_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.payment_transactions import Payment_transactions
 
 non_id_columns = ['account_id',
-	'payment_method_id',
-	'reference_type',
-	'reference_id',
-	'amount',
-	'currency',
-	'direction',
-	'transaction_date',
-	'created_at']
+    'payment_method_id',
+    'reference_type',
+    'reference_id',
+    'amount',
+    'currency',
+    'direction',
+    'transaction_date',
+    'created_at']
 
 payment_transactions_bp = Blueprint('payment_transactions',
     __name__,
@@ -35,7 +35,7 @@ payment_transactions_bp = Blueprint('payment_transactions',
 def get_payment_transactions(payment_transactions_id):
     """
     Logic to get payment_transactions data
-    
+
     Parameter:
     payment_transactions_id (int): Id of the payment_transactions-object
 
@@ -59,24 +59,24 @@ def create_payment_transactions():
             otherwise an error message
     """
     result = Payment_transactions.create(account_id=request.values.get('account_id'),
-		payment_method_id=request.values.get('payment_method_id'),
-		reference_type=request.values.get('reference_type'),
-		reference_id=request.values.get('reference_id'),
-		amount=request.values.get('amount'),
-		currency=request.values.get('currency'),
-		direction=request.values.get('direction'),
-		transaction_date=request.values.get('transaction_date'),
-		created_at=request.values.get('created_at'))
+        payment_method_id=request.values.get('payment_method_id'),
+        reference_type=request.values.get('reference_type'),
+        reference_id=request.values.get('reference_id'),
+        amount=request.values.get('amount'),
+        currency=request.values.get('currency'),
+        direction=request.values.get('direction'),
+        transaction_date=request.values.get('transaction_date'),
+        created_at=request.values.get('created_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @payment_transactions_bp.route('/<int:payment_transactions_id>', methods=['PUT'])
 @jwt_required()
 def update_payment_transactions(payment_transactions_id):
     """
     Logic to update payment_transactions data
-    
+
     Parameter:
         payment_transactions_id (int): Id of the payment_transactions-object
 
@@ -89,14 +89,13 @@ def update_payment_transactions(payment_transactions_id):
     result = Payment_transactions.update(payment_transactions_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @payment_transactions_bp.route('/<int:payment_transactions_id>', methods=['DELETE'])
 @jwt_required()
 def delete_payment_transactions(payment_transactions_id):
     """
     Logic to delete payment_transactions data
-    
     Parameter:
         payment_transactions_id (int): Id of the payment_transactions-object
 
@@ -107,4 +106,4 @@ def delete_payment_transactions(payment_transactions_id):
     result = Payment_transactions.delete(payment_transactions_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/pos_terminals.py
+++ b/app/api/blueprints/pos_terminals.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    pos_terminals_id    
+    pos_terminals_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.pos_terminals import Pos_terminals
 
 non_id_columns = ['branch_id',
-	'terminal_code',
-	'description',
-	'is_active']
+    'terminal_code',
+    'description',
+    'is_active']
 
 pos_terminals_bp = Blueprint('pos_terminals',
     __name__,
@@ -30,7 +30,7 @@ pos_terminals_bp = Blueprint('pos_terminals',
 def get_pos_terminals(pos_terminals_id):
     """
     Logic to get pos_terminals data
-    
+
     Parameter:
     pos_terminals_id (int): Id of the pos_terminals-object
 
@@ -54,19 +54,19 @@ def create_pos_terminals():
             otherwise an error message
     """
     result = Pos_terminals.create(branch_id=request.values.get('branch_id'),
-		terminal_code=request.values.get('terminal_code'),
-		description=request.values.get('description'),
-		is_active=request.values.get('is_active'))
+        terminal_code=request.values.get('terminal_code'),
+        description=request.values.get('description'),
+        is_active=request.values.get('is_active'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @pos_terminals_bp.route('/<int:pos_terminals_id>', methods=['PUT'])
 @jwt_required()
 def update_pos_terminals(pos_terminals_id):
     """
     Logic to update pos_terminals data
-    
+
     Parameter:
         pos_terminals_id (int): Id of the pos_terminals-object
 
@@ -79,14 +79,14 @@ def update_pos_terminals(pos_terminals_id):
     result = Pos_terminals.update(pos_terminals_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @pos_terminals_bp.route('/<int:pos_terminals_id>', methods=['DELETE'])
 @jwt_required()
 def delete_pos_terminals(pos_terminals_id):
     """
     Logic to delete pos_terminals data
-    
+
     Parameter:
         pos_terminals_id (int): Id of the pos_terminals-object
 
@@ -97,4 +97,4 @@ def delete_pos_terminals(pos_terminals_id):
     result = Pos_terminals.delete(pos_terminals_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/product_allergens.py
+++ b/app/api/blueprints/product_allergens.py
@@ -10,14 +10,14 @@ Functions:
 
 Misc variables:
 
-    product_allergens_id    
+    product_allergens_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.product_allergens import Product_allergens
 
 non_id_columns = ['product_id',
-	'allergen_id']
+    'allergen_id']
 
 product_allergens_bp = Blueprint('product_allergens',
     __name__,
@@ -28,7 +28,7 @@ product_allergens_bp = Blueprint('product_allergens',
 def get_product_allergens(product_allergens_id):
     """
     Logic to get product_allergens data
-    
+
     Parameter:
     product_allergens_id (int): Id of the product_allergens-object
 
@@ -52,17 +52,17 @@ def create_product_allergens():
             otherwise an error message
     """
     result = Product_allergens.create(product_id=request.values.get('product_id'),
-		allergen_id=request.values.get('allergen_id'))
+        allergen_id=request.values.get('allergen_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @product_allergens_bp.route('/<int:product_allergens_id>', methods=['PUT'])
 @jwt_required()
 def update_product_allergens(product_allergens_id):
     """
     Logic to update product_allergens data
-    
+
     Parameter:
         product_allergens_id (int): Id of the product_allergens-object
 
@@ -75,14 +75,14 @@ def update_product_allergens(product_allergens_id):
     result = Product_allergens.update(product_allergens_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @product_allergens_bp.route('/<int:product_allergens_id>', methods=['DELETE'])
 @jwt_required()
 def delete_product_allergens(product_allergens_id):
     """
     Logic to delete product_allergens data
-    
+
     Parameter:
         product_allergens_id (int): Id of the product_allergens-object
 
@@ -93,4 +93,4 @@ def delete_product_allergens(product_allergens_id):
     result = Product_allergens.delete(product_allergens_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/production_feedback.py
+++ b/app/api/blueprints/production_feedback.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    production_feedback_id    
+    production_feedback_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.production_feedback import Production_feedback
 
 non_id_columns = ['plan_item_id',
-	'user_id',
-	'produced_qty',
-	'timestamp']
+    'user_id',
+    'produced_qty',
+    'timestamp']
 
 production_feedback_bp = Blueprint('production_feedback',
     __name__,
@@ -30,7 +30,7 @@ production_feedback_bp = Blueprint('production_feedback',
 def get_production_feedback(production_feedback_id):
     """
     Logic to get production_feedback data
-    
+
     Parameter:
     production_feedback_id (int): Id of the production_feedback-object
 
@@ -54,19 +54,19 @@ def create_production_feedback():
             otherwise an error message
     """
     result = Production_feedback.create(plan_item_id=request.values.get('plan_item_id'),
-		user_id=request.values.get('user_id'),
-		produced_qty=request.values.get('produced_qty'),
-		timestamp=request.values.get('timestamp'))
+        user_id=request.values.get('user_id'),
+        produced_qty=request.values.get('produced_qty'),
+        timestamp=request.values.get('timestamp'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_feedback_bp.route('/<int:production_feedback_id>', methods=['PUT'])
 @jwt_required()
 def update_production_feedback(production_feedback_id):
     """
     Logic to update production_feedback data
-    
+
     Parameter:
         production_feedback_id (int): Id of the production_feedback-object
 
@@ -79,14 +79,14 @@ def update_production_feedback(production_feedback_id):
     result = Production_feedback.update(production_feedback_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_feedback_bp.route('/<int:production_feedback_id>', methods=['DELETE'])
 @jwt_required()
 def delete_production_feedback(production_feedback_id):
     """
     Logic to delete production_feedback data
-    
+
     Parameter:
         production_feedback_id (int): Id of the production_feedback-object
 
@@ -97,4 +97,4 @@ def delete_production_feedback(production_feedback_id):
     result = Production_feedback.delete(production_feedback_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/production_plan_items.py
+++ b/app/api/blueprints/production_plan_items.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    production_plan_items_id    
+    production_plan_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.production_plan_items import Production_plan_items
 
 non_id_columns = ['plan_id',
-	'product_id',
-	'planned_qty',
-	'produced_qty']
+    'product_id',
+    'planned_qty',
+    'produced_qty']
 
 production_plan_items_bp = Blueprint('production_plan_items',
     __name__,
@@ -30,7 +30,7 @@ production_plan_items_bp = Blueprint('production_plan_items',
 def get_production_plan_items(production_plan_items_id):
     """
     Logic to get production_plan_items data
-    
+
     Parameter:
     production_plan_items_id (int): Id of the production_plan_items-object
 
@@ -54,19 +54,19 @@ def create_production_plan_items():
             otherwise an error message
     """
     result = Production_plan_items.create(plan_id=request.values.get('plan_id'),
-		product_id=request.values.get('product_id'),
-		planned_qty=request.values.get('planned_qty'),
-		produced_qty=request.values.get('produced_qty'))
+        product_id=request.values.get('product_id'),
+        planned_qty=request.values.get('planned_qty'),
+        produced_qty=request.values.get('produced_qty'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_plan_items_bp.route('/<int:production_plan_items_id>', methods=['PUT'])
 @jwt_required()
 def update_production_plan_items(production_plan_items_id):
     """
     Logic to update production_plan_items data
-    
+
     Parameter:
         production_plan_items_id (int): Id of the production_plan_items-object
 
@@ -79,14 +79,14 @@ def update_production_plan_items(production_plan_items_id):
     result = Production_plan_items.update(production_plan_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_plan_items_bp.route('/<int:production_plan_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_production_plan_items(production_plan_items_id):
     """
     Logic to delete production_plan_items data
-    
+
     Parameter:
         production_plan_items_id (int): Id of the production_plan_items-object
 
@@ -97,4 +97,4 @@ def delete_production_plan_items(production_plan_items_id):
     result = Production_plan_items.delete(production_plan_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/production_plans.py
+++ b/app/api/blueprints/production_plans.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    production_plans_id    
+    production_plans_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.production_plans import Production_plans
 
 non_id_columns = ['branch_id',
-	'planned_date',
-	'status',
-	'created_at',
-	'updated_at']
+    'planned_date',
+    'status',
+    'created_at',
+    'updated_at']
 
 production_plans_bp = Blueprint('production_plans',
     __name__,
@@ -31,7 +31,7 @@ production_plans_bp = Blueprint('production_plans',
 def get_production_plans(production_plans_id):
     """
     Logic to get production_plans data
-    
+
     Parameter:
     production_plans_id (int): Id of the production_plans-object
 
@@ -55,20 +55,20 @@ def create_production_plans():
             otherwise an error message
     """
     result = Production_plans.create(branch_id=request.values.get('branch_id'),
-		planned_date=request.values.get('planned_date'),
-		status=request.values.get('status'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        planned_date=request.values.get('planned_date'),
+        status=request.values.get('status'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_plans_bp.route('/<int:production_plans_id>', methods=['PUT'])
 @jwt_required()
 def update_production_plans(production_plans_id):
     """
     Logic to update production_plans data
-    
+
     Parameter:
         production_plans_id (int): Id of the production_plans-object
 
@@ -81,14 +81,14 @@ def update_production_plans(production_plans_id):
     result = Production_plans.update(production_plans_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @production_plans_bp.route('/<int:production_plans_id>', methods=['DELETE'])
 @jwt_required()
 def delete_production_plans(production_plans_id):
     """
     Logic to delete production_plans data
-    
+
     Parameter:
         production_plans_id (int): Id of the production_plans-object
 
@@ -99,4 +99,4 @@ def delete_production_plans(production_plans_id):
     result = Production_plans.delete(production_plans_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/products.py
+++ b/app/api/blueprints/products.py
@@ -10,20 +10,20 @@ Functions:
 
 Misc variables:
 
-    products_id    
+    products_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.products import Products
 
 non_id_columns = ['name',
-	'sku',
-	'recipe_id',
-	'sales_price',
-	'tax_code_id',
-	'is_active',
-	'created_at',
-	'updated_at']
+    'sku',
+    'recipe_id',
+    'sales_price',
+    'tax_code_id',
+    'is_active',
+    'created_at',
+    'updated_at']
 
 products_bp = Blueprint('products',
     __name__,
@@ -34,7 +34,7 @@ products_bp = Blueprint('products',
 def get_products(products_id):
     """
     Logic to get products data
-    
+
     Parameter:
     products_id (int): Id of the products-object
 
@@ -58,23 +58,23 @@ def create_products():
             otherwise an error message
     """
     result = Products.create(name=request.values.get('name'),
-		sku=request.values.get('sku'),
-		recipe_id=request.values.get('recipe_id'),
-		sales_price=request.values.get('sales_price'),
-		tax_code_id=request.values.get('tax_code_id'),
-		is_active=request.values.get('is_active'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        sku=request.values.get('sku'),
+        recipe_id=request.values.get('recipe_id'),
+        sales_price=request.values.get('sales_price'),
+        tax_code_id=request.values.get('tax_code_id'),
+        is_active=request.values.get('is_active'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @products_bp.route('/<int:products_id>', methods=['PUT'])
 @jwt_required()
 def update_products(products_id):
     """
     Logic to update products data
-    
+
     Parameter:
         products_id (int): Id of the products-object
 
@@ -87,14 +87,14 @@ def update_products(products_id):
     result = Products.update(products_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @products_bp.route('/<int:products_id>', methods=['DELETE'])
 @jwt_required()
 def delete_products(products_id):
     """
     Logic to delete products data
-    
+
     Parameter:
         products_id (int): Id of the products-object
 
@@ -105,4 +105,4 @@ def delete_products(products_id):
     result = Products.delete(products_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/recipe_items.py
+++ b/app/api/blueprints/recipe_items.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    recipe_items_id    
+    recipe_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.recipe_items import Recipe_items
 
 non_id_columns = ['recipe_id',
-	'ingredient_id',
-	'quantity',
-	'unit']
+    'ingredient_id',
+    'quantity',
+    'unit']
 
 recipe_items_bp = Blueprint('recipe_items',
     __name__,
@@ -30,7 +30,7 @@ recipe_items_bp = Blueprint('recipe_items',
 def get_recipe_items(recipe_items_id):
     """
     Logic to get recipe_items data
-    
+
     Parameter:
     recipe_items_id (int): Id of the recipe_items-object
 
@@ -54,19 +54,19 @@ def create_recipe_items():
             otherwise an error message
     """
     result = Recipe_items.create(recipe_id=request.values.get('recipe_id'),
-		ingredient_id=request.values.get('ingredient_id'),
-		quantity=request.values.get('quantity'),
-		unit=request.values.get('unit'))
+        ingredient_id=request.values.get('ingredient_id'),
+        quantity=request.values.get('quantity'),
+        unit=request.values.get('unit'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @recipe_items_bp.route('/<int:recipe_items_id>', methods=['PUT'])
 @jwt_required()
 def update_recipe_items(recipe_items_id):
     """
     Logic to update recipe_items data
-    
+
     Parameter:
         recipe_items_id (int): Id of the recipe_items-object
 
@@ -79,14 +79,14 @@ def update_recipe_items(recipe_items_id):
     result = Recipe_items.update(recipe_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @recipe_items_bp.route('/<int:recipe_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_recipe_items(recipe_items_id):
     """
     Logic to delete recipe_items data
-    
+
     Parameter:
         recipe_items_id (int): Id of the recipe_items-object
 
@@ -97,4 +97,4 @@ def delete_recipe_items(recipe_items_id):
     result = Recipe_items.delete(recipe_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/recipes.py
+++ b/app/api/blueprints/recipes.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    recipes_id    
+    recipes_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.recipes import Recipes
 
 non_id_columns = ['name',
-	'description',
-	'created_at',
-	'updated_at']
+    'description',
+    'created_at',
+    'updated_at']
 
 recipes_bp = Blueprint('recipes',
     __name__,
@@ -30,7 +30,7 @@ recipes_bp = Blueprint('recipes',
 def get_recipes(recipes_id):
     """
     Logic to get recipes data
-    
+
     Parameter:
     recipes_id (int): Id of the recipes-object
 
@@ -54,19 +54,19 @@ def create_recipes():
             otherwise an error message
     """
     result = Recipes.create(name=request.values.get('name'),
-		description=request.values.get('description'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        description=request.values.get('description'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @recipes_bp.route('/<int:recipes_id>', methods=['PUT'])
 @jwt_required()
 def update_recipes(recipes_id):
     """
     Logic to update recipes data
-    
+
     Parameter:
         recipes_id (int): Id of the recipes-object
 
@@ -79,14 +79,14 @@ def update_recipes(recipes_id):
     result = Recipes.update(recipes_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @recipes_bp.route('/<int:recipes_id>', methods=['DELETE'])
 @jwt_required()
 def delete_recipes(recipes_id):
     """
     Logic to delete recipes data
-    
+
     Parameter:
         recipes_id (int): Id of the recipes-object
 
@@ -97,4 +97,4 @@ def delete_recipes(recipes_id):
     result = Recipes.delete(recipes_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/refund_items.py
+++ b/app/api/blueprints/refund_items.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    refund_items_id    
+    refund_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.refund_items import Refund_items
 
 non_id_columns = ['refund_id',
-	'product_id',
-	'qty',
-	'unit_price',
-	'tax_code_id']
+    'product_id',
+    'qty',
+    'unit_price',
+    'tax_code_id']
 
 refund_items_bp = Blueprint('refund_items',
     __name__,
@@ -31,7 +31,7 @@ refund_items_bp = Blueprint('refund_items',
 def get_refund_items(refund_items_id):
     """
     Logic to get refund_items data
-    
+
     Parameter:
     refund_items_id (int): Id of the refund_items-object
 
@@ -55,20 +55,20 @@ def create_refund_items():
             otherwise an error message
     """
     result = Refund_items.create(refund_id=request.values.get('refund_id'),
-		product_id=request.values.get('product_id'),
-		qty=request.values.get('qty'),
-		unit_price=request.values.get('unit_price'),
-		tax_code_id=request.values.get('tax_code_id'))
+        product_id=request.values.get('product_id'),
+        qty=request.values.get('qty'),
+        unit_price=request.values.get('unit_price'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refund_items_bp.route('/<int:refund_items_id>', methods=['PUT'])
 @jwt_required()
 def update_refund_items(refund_items_id):
     """
     Logic to update refund_items data
-    
+
     Parameter:
         refund_items_id (int): Id of the refund_items-object
 
@@ -81,14 +81,14 @@ def update_refund_items(refund_items_id):
     result = Refund_items.update(refund_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refund_items_bp.route('/<int:refund_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_refund_items(refund_items_id):
     """
     Logic to delete refund_items data
-    
+
     Parameter:
         refund_items_id (int): Id of the refund_items-object
 
@@ -99,4 +99,4 @@ def delete_refund_items(refund_items_id):
     result = Refund_items.delete(refund_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/refund_reasons.py
+++ b/app/api/blueprints/refund_reasons.py
@@ -10,14 +10,14 @@ Functions:
 
 Misc variables:
 
-    refund_reasons_id    
+    refund_reasons_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.refund_reasons import Refund_reasons
 
 non_id_columns = ['code',
-	'description']
+    'description']
 
 refund_reasons_bp = Blueprint('refund_reasons',
     __name__,
@@ -28,7 +28,7 @@ refund_reasons_bp = Blueprint('refund_reasons',
 def get_refund_reasons(refund_reasons_id):
     """
     Logic to get refund_reasons data
-    
+
     Parameter:
     refund_reasons_id (int): Id of the refund_reasons-object
 
@@ -52,17 +52,17 @@ def create_refund_reasons():
             otherwise an error message
     """
     result = Refund_reasons.create(code=request.values.get('code'),
-		description=request.values.get('description'))
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refund_reasons_bp.route('/<int:refund_reasons_id>', methods=['PUT'])
 @jwt_required()
 def update_refund_reasons(refund_reasons_id):
     """
     Logic to update refund_reasons data
-    
+
     Parameter:
         refund_reasons_id (int): Id of the refund_reasons-object
 
@@ -75,14 +75,14 @@ def update_refund_reasons(refund_reasons_id):
     result = Refund_reasons.update(refund_reasons_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refund_reasons_bp.route('/<int:refund_reasons_id>', methods=['DELETE'])
 @jwt_required()
 def delete_refund_reasons(refund_reasons_id):
     """
     Logic to delete refund_reasons data
-    
+
     Parameter:
         refund_reasons_id (int): Id of the refund_reasons-object
 
@@ -93,4 +93,4 @@ def delete_refund_reasons(refund_reasons_id):
     result = Refund_reasons.delete(refund_reasons_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/refunds.py
+++ b/app/api/blueprints/refunds.py
@@ -10,22 +10,22 @@ Functions:
 
 Misc variables:
 
-    refunds_id    
+    refunds_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.refunds import Refunds
 
 non_id_columns = ['receipt_id',
-	'order_id',
-	'refund_datetime',
-	'total_refund_amount',
-	'payment_method_id',
-	'account_id',
-	'reason_id',
-	'created_by',
-	'note',
-	'created_at']
+    'order_id',
+    'refund_datetime',
+    'total_refund_amount',
+    'payment_method_id',
+    'account_id',
+    'reason_id',
+    'created_by',
+    'note',
+    'created_at']
 
 refunds_bp = Blueprint('refunds',
     __name__,
@@ -36,7 +36,7 @@ refunds_bp = Blueprint('refunds',
 def get_refunds(refunds_id):
     """
     Logic to get refunds data
-    
+
     Parameter:
     refunds_id (int): Id of the refunds-object
 
@@ -60,25 +60,25 @@ def create_refunds():
             otherwise an error message
     """
     result = Refunds.create(receipt_id=request.values.get('receipt_id'),
-		order_id=request.values.get('order_id'),
-		refund_datetime=request.values.get('refund_datetime'),
-		total_refund_amount=request.values.get('total_refund_amount'),
-		payment_method_id=request.values.get('payment_method_id'),
-		account_id=request.values.get('account_id'),
-		reason_id=request.values.get('reason_id'),
-		created_by=request.values.get('created_by'),
-		note=request.values.get('note'),
-		created_at=request.values.get('created_at'))
+        order_id=request.values.get('order_id'),
+        refund_datetime=request.values.get('refund_datetime'),
+        total_refund_amount=request.values.get('total_refund_amount'),
+        payment_method_id=request.values.get('payment_method_id'),
+        account_id=request.values.get('account_id'),
+        reason_id=request.values.get('reason_id'),
+        created_by=request.values.get('created_by'),
+        note=request.values.get('note'),
+        created_at=request.values.get('created_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refunds_bp.route('/<int:refunds_id>', methods=['PUT'])
 @jwt_required()
 def update_refunds(refunds_id):
     """
     Logic to update refunds data
-    
+
     Parameter:
         refunds_id (int): Id of the refunds-object
 
@@ -91,14 +91,14 @@ def update_refunds(refunds_id):
     result = Refunds.update(refunds_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @refunds_bp.route('/<int:refunds_id>', methods=['DELETE'])
 @jwt_required()
 def delete_refunds(refunds_id):
     """
     Logic to delete refunds data
-    
+
     Parameter:
         refunds_id (int): Id of the refunds-object
 
@@ -109,4 +109,4 @@ def delete_refunds(refunds_id):
     result = Refunds.delete(refunds_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/roles.py
+++ b/app/api/blueprints/roles.py
@@ -10,14 +10,14 @@ Functions:
 
 Misc variables:
 
-    roles_id    
+    roles_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.roles import Roles
 
 non_id_columns = ['name',
-	'description']
+    'description']
 
 roles_bp = Blueprint('roles',
     __name__,
@@ -28,7 +28,7 @@ roles_bp = Blueprint('roles',
 def get_roles(roles_id):
     """
     Logic to get roles data
-    
+
     Parameter:
     roles_id (int): Id of the roles-object
 
@@ -52,17 +52,17 @@ def create_roles():
             otherwise an error message
     """
     result = Roles.create(name=request.values.get('name'),
-		description=request.values.get('description'))
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @roles_bp.route('/<int:roles_id>', methods=['PUT'])
 @jwt_required()
 def update_roles(roles_id):
     """
     Logic to update roles data
-    
+
     Parameter:
         roles_id (int): Id of the roles-object
 
@@ -75,14 +75,14 @@ def update_roles(roles_id):
     result = Roles.update(roles_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @roles_bp.route('/<int:roles_id>', methods=['DELETE'])
 @jwt_required()
 def delete_roles(roles_id):
     """
     Logic to delete roles data
-    
+
     Parameter:
         roles_id (int): Id of the roles-object
 
@@ -93,4 +93,4 @@ def delete_roles(roles_id):
     result = Roles.delete(roles_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/sales_receipt_items.py
+++ b/app/api/blueprints/sales_receipt_items.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    sales_receipt_items_id    
+    sales_receipt_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.sales_receipt_items import Sales_receipt_items
 
 non_id_columns = ['receipt_id',
-	'product_id',
-	'qty',
-	'unit_price',
-	'tax_code_id']
+    'product_id',
+    'qty',
+    'unit_price',
+    'tax_code_id']
 
 sales_receipt_items_bp = Blueprint('sales_receipt_items',
     __name__,
@@ -31,7 +31,7 @@ sales_receipt_items_bp = Blueprint('sales_receipt_items',
 def get_sales_receipt_items(sales_receipt_items_id):
     """
     Logic to get sales_receipt_items data
-    
+
     Parameter:
     sales_receipt_items_id (int): Id of the sales_receipt_items-object
 
@@ -55,20 +55,20 @@ def create_sales_receipt_items():
             otherwise an error message
     """
     result = Sales_receipt_items.create(receipt_id=request.values.get('receipt_id'),
-		product_id=request.values.get('product_id'),
-		qty=request.values.get('qty'),
-		unit_price=request.values.get('unit_price'),
-		tax_code_id=request.values.get('tax_code_id'))
+        product_id=request.values.get('product_id'),
+        qty=request.values.get('qty'),
+        unit_price=request.values.get('unit_price'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @sales_receipt_items_bp.route('/<int:sales_receipt_items_id>', methods=['PUT'])
 @jwt_required()
 def update_sales_receipt_items(sales_receipt_items_id):
     """
     Logic to update sales_receipt_items data
-    
+
     Parameter:
         sales_receipt_items_id (int): Id of the sales_receipt_items-object
 
@@ -81,14 +81,14 @@ def update_sales_receipt_items(sales_receipt_items_id):
     result = Sales_receipt_items.update(sales_receipt_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @sales_receipt_items_bp.route('/<int:sales_receipt_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_sales_receipt_items(sales_receipt_items_id):
     """
     Logic to delete sales_receipt_items data
-    
+
     Parameter:
         sales_receipt_items_id (int): Id of the sales_receipt_items-object
 
@@ -99,4 +99,4 @@ def delete_sales_receipt_items(sales_receipt_items_id):
     result = Sales_receipt_items.delete(sales_receipt_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/sales_receipts.py
+++ b/app/api/blueprints/sales_receipts.py
@@ -10,20 +10,20 @@ Functions:
 
 Misc variables:
 
-    sales_receipts_id    
+    sales_receipts_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.sales_receipts import Sales_receipts
 
 non_id_columns = ['receipt_number',
-	'branch_id',
-	'pos_terminal_id',
-	'sale_datetime',
-	'customer_id',
-	'total_amount',
-	'payment_method_id',
-	'payment_reference']
+    'branch_id',
+    'pos_terminal_id',
+    'sale_datetime',
+    'customer_id',
+    'total_amount',
+    'payment_method_id',
+    'payment_reference']
 
 sales_receipts_bp = Blueprint('sales_receipts',
     __name__,
@@ -34,7 +34,7 @@ sales_receipts_bp = Blueprint('sales_receipts',
 def get_sales_receipts(sales_receipts_id):
     """
     Logic to get sales_receipts data
-    
+
     Parameter:
     sales_receipts_id (int): Id of the sales_receipts-object
 
@@ -58,23 +58,23 @@ def create_sales_receipts():
             otherwise an error message
     """
     result = Sales_receipts.create(receipt_number=request.values.get('receipt_number'),
-		branch_id=request.values.get('branch_id'),
-		pos_terminal_id=request.values.get('pos_terminal_id'),
-		sale_datetime=request.values.get('sale_datetime'),
-		customer_id=request.values.get('customer_id'),
-		total_amount=request.values.get('total_amount'),
-		payment_method_id=request.values.get('payment_method_id'),
-		payment_reference=request.values.get('payment_reference'))
+        branch_id=request.values.get('branch_id'),
+        pos_terminal_id=request.values.get('pos_terminal_id'),
+        sale_datetime=request.values.get('sale_datetime'),
+        customer_id=request.values.get('customer_id'),
+        total_amount=request.values.get('total_amount'),
+        payment_method_id=request.values.get('payment_method_id'),
+        payment_reference=request.values.get('payment_reference'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @sales_receipts_bp.route('/<int:sales_receipts_id>', methods=['PUT'])
 @jwt_required()
 def update_sales_receipts(sales_receipts_id):
     """
     Logic to update sales_receipts data
-    
+
     Parameter:
         sales_receipts_id (int): Id of the sales_receipts-object
 
@@ -87,14 +87,14 @@ def update_sales_receipts(sales_receipts_id):
     result = Sales_receipts.update(sales_receipts_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @sales_receipts_bp.route('/<int:sales_receipts_id>', methods=['DELETE'])
 @jwt_required()
 def delete_sales_receipts(sales_receipts_id):
     """
     Logic to delete sales_receipts data
-    
+
     Parameter:
         sales_receipts_id (int): Id of the sales_receipts-object
 
@@ -105,4 +105,4 @@ def delete_sales_receipts(sales_receipts_id):
     result = Sales_receipts.delete(sales_receipts_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/shift_schedule.py
+++ b/app/api/blueprints/shift_schedule.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    shift_schedule_id    
+    shift_schedule_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.shift_schedule import Shift_schedule
 
 non_id_columns = ['shift_id',
-	'employee_id',
-	'schedule_date',
-	'assigned_hours']
+    'employee_id',
+    'schedule_date',
+    'assigned_hours']
 
 shift_schedule_bp = Blueprint('shift_schedule',
     __name__,
@@ -30,7 +30,7 @@ shift_schedule_bp = Blueprint('shift_schedule',
 def get_shift_schedule(shift_schedule_id):
     """
     Logic to get shift_schedule data
-    
+
     Parameter:
     shift_schedule_id (int): Id of the shift_schedule-object
 
@@ -54,19 +54,19 @@ def create_shift_schedule():
             otherwise an error message
     """
     result = Shift_schedule.create(shift_id=request.values.get('shift_id'),
-		employee_id=request.values.get('employee_id'),
-		schedule_date=request.values.get('schedule_date'),
-		assigned_hours=request.values.get('assigned_hours'))
+        employee_id=request.values.get('employee_id'),
+        schedule_date=request.values.get('schedule_date'),
+        assigned_hours=request.values.get('assigned_hours'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @shift_schedule_bp.route('/<int:shift_schedule_id>', methods=['PUT'])
 @jwt_required()
 def update_shift_schedule(shift_schedule_id):
     """
     Logic to update shift_schedule data
-    
+
     Parameter:
         shift_schedule_id (int): Id of the shift_schedule-object
 
@@ -79,14 +79,14 @@ def update_shift_schedule(shift_schedule_id):
     result = Shift_schedule.update(shift_schedule_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @shift_schedule_bp.route('/<int:shift_schedule_id>', methods=['DELETE'])
 @jwt_required()
 def delete_shift_schedule(shift_schedule_id):
     """
     Logic to delete shift_schedule data
-    
+
     Parameter:
         shift_schedule_id (int): Id of the shift_schedule-object
 
@@ -97,4 +97,4 @@ def delete_shift_schedule(shift_schedule_id):
     result = Shift_schedule.delete(shift_schedule_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/shifts.py
+++ b/app/api/blueprints/shifts.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    shifts_id    
+    shifts_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.shifts import Shifts
 
 non_id_columns = ['branch_id',
-	'name',
-	'start_time',
-	'end_time']
+    'name',
+    'start_time',
+    'end_time']
 
 shifts_bp = Blueprint('shifts',
     __name__,
@@ -30,7 +30,7 @@ shifts_bp = Blueprint('shifts',
 def get_shifts(shifts_id):
     """
     Logic to get shifts data
-    
+
     Parameter:
     shifts_id (int): Id of the shifts-object
 
@@ -54,19 +54,19 @@ def create_shifts():
             otherwise an error message
     """
     result = Shifts.create(branch_id=request.values.get('branch_id'),
-		name=request.values.get('name'),
-		start_time=request.values.get('start_time'),
-		end_time=request.values.get('end_time'))
+        name=request.values.get('name'),
+        start_time=request.values.get('start_time'),
+        end_time=request.values.get('end_time'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @shifts_bp.route('/<int:shifts_id>', methods=['PUT'])
 @jwt_required()
 def update_shifts(shifts_id):
     """
     Logic to update shifts data
-    
+
     Parameter:
         shifts_id (int): Id of the shifts-object
 
@@ -79,14 +79,14 @@ def update_shifts(shifts_id):
     result = Shifts.update(shifts_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @shifts_bp.route('/<int:shifts_id>', methods=['DELETE'])
 @jwt_required()
 def delete_shifts(shifts_id):
     """
     Logic to delete shifts data
-    
+
     Parameter:
         shifts_id (int): Id of the shifts-object
 
@@ -97,4 +97,4 @@ def delete_shifts(shifts_id):
     result = Shifts.delete(shifts_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/supplier_invoice_items.py
+++ b/app/api/blueprints/supplier_invoice_items.py
@@ -10,17 +10,17 @@ Functions:
 
 Misc variables:
 
-    supplier_invoice_items_id    
+    supplier_invoice_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.supplier_invoice_items import Supplier_invoice_items
 
 non_id_columns = ['invoice_id',
-	'ingredient_id',
-	'qty',
-	'unit_price',
-	'tax_code_id']
+    'ingredient_id',
+    'qty',
+    'unit_price',
+    'tax_code_id']
 
 supplier_invoice_items_bp = Blueprint('supplier_invoice_items',
     __name__,
@@ -31,7 +31,7 @@ supplier_invoice_items_bp = Blueprint('supplier_invoice_items',
 def get_supplier_invoice_items(supplier_invoice_items_id):
     """
     Logic to get supplier_invoice_items data
-    
+
     Parameter:
     supplier_invoice_items_id (int): Id of the supplier_invoice_items-object
 
@@ -55,20 +55,20 @@ def create_supplier_invoice_items():
             otherwise an error message
     """
     result = Supplier_invoice_items.create(invoice_id=request.values.get('invoice_id'),
-		ingredient_id=request.values.get('ingredient_id'),
-		qty=request.values.get('qty'),
-		unit_price=request.values.get('unit_price'),
-		tax_code_id=request.values.get('tax_code_id'))
+        ingredient_id=request.values.get('ingredient_id'),
+        qty=request.values.get('qty'),
+        unit_price=request.values.get('unit_price'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_invoice_items_bp.route('/<int:supplier_invoice_items_id>', methods=['PUT'])
 @jwt_required()
 def update_supplier_invoice_items(supplier_invoice_items_id):
     """
     Logic to update supplier_invoice_items data
-    
+
     Parameter:
         supplier_invoice_items_id (int): Id of the supplier_invoice_items-object
 
@@ -81,14 +81,14 @@ def update_supplier_invoice_items(supplier_invoice_items_id):
     result = Supplier_invoice_items.update(supplier_invoice_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_invoice_items_bp.route('/<int:supplier_invoice_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_supplier_invoice_items(supplier_invoice_items_id):
     """
     Logic to delete supplier_invoice_items data
-    
+
     Parameter:
         supplier_invoice_items_id (int): Id of the supplier_invoice_items-object
 
@@ -99,4 +99,4 @@ def delete_supplier_invoice_items(supplier_invoice_items_id):
     result = Supplier_invoice_items.delete(supplier_invoice_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/supplier_invoices.py
+++ b/app/api/blueprints/supplier_invoices.py
@@ -10,19 +10,19 @@ Functions:
 
 Misc variables:
 
-    supplier_invoices_id    
+    supplier_invoices_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.supplier_invoices import Supplier_invoices
 
 non_id_columns = ['invoice_number',
-	'supplier_id',
-	'supplier_order_id',
-	'invoice_date',
-	'due_date',
-	'total_amount',
-	'payment_status']
+    'supplier_id',
+    'supplier_order_id',
+    'invoice_date',
+    'due_date',
+    'total_amount',
+    'payment_status']
 
 supplier_invoices_bp = Blueprint('supplier_invoices',
     __name__,
@@ -33,7 +33,7 @@ supplier_invoices_bp = Blueprint('supplier_invoices',
 def get_supplier_invoices(supplier_invoices_id):
     """
     Logic to get supplier_invoices data
-    
+
     Parameter:
     supplier_invoices_id (int): Id of the supplier_invoices-object
 
@@ -57,22 +57,22 @@ def create_supplier_invoices():
             otherwise an error message
     """
     result = Supplier_invoices.create(invoice_number=request.values.get('invoice_number'),
-		supplier_id=request.values.get('supplier_id'),
-		supplier_order_id=request.values.get('supplier_order_id'),
-		invoice_date=request.values.get('invoice_date'),
-		due_date=request.values.get('due_date'),
-		total_amount=request.values.get('total_amount'),
-		payment_status=request.values.get('payment_status'))
+        supplier_id=request.values.get('supplier_id'),
+        supplier_order_id=request.values.get('supplier_order_id'),
+        invoice_date=request.values.get('invoice_date'),
+        due_date=request.values.get('due_date'),
+        total_amount=request.values.get('total_amount'),
+        payment_status=request.values.get('payment_status'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_invoices_bp.route('/<int:supplier_invoices_id>', methods=['PUT'])
 @jwt_required()
 def update_supplier_invoices(supplier_invoices_id):
     """
     Logic to update supplier_invoices data
-    
+
     Parameter:
         supplier_invoices_id (int): Id of the supplier_invoices-object
 
@@ -85,14 +85,14 @@ def update_supplier_invoices(supplier_invoices_id):
     result = Supplier_invoices.update(supplier_invoices_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_invoices_bp.route('/<int:supplier_invoices_id>', methods=['DELETE'])
 @jwt_required()
 def delete_supplier_invoices(supplier_invoices_id):
     """
     Logic to delete supplier_invoices data
-    
+
     Parameter:
         supplier_invoices_id (int): Id of the supplier_invoices-object
 
@@ -103,4 +103,4 @@ def delete_supplier_invoices(supplier_invoices_id):
     result = Supplier_invoices.delete(supplier_invoices_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/supplier_order_items.py
+++ b/app/api/blueprints/supplier_order_items.py
@@ -10,20 +10,20 @@ Functions:
 
 Misc variables:
 
-    supplier_order_items_id    
+    supplier_order_items_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.supplier_order_items import Supplier_order_items
 
 non_id_columns = ['order_id',
-	'ingredient_id',
-	'qty',
-	'unit_price',
-	'received_amount',
-	'received',
-	'received_at',
-	'tax_code_id']
+    'ingredient_id',
+    'qty',
+    'unit_price',
+    'received_amount',
+    'received',
+    'received_at',
+    'tax_code_id']
 
 supplier_order_items_bp = Blueprint('supplier_order_items',
     __name__,
@@ -34,7 +34,7 @@ supplier_order_items_bp = Blueprint('supplier_order_items',
 def get_supplier_order_items(supplier_order_items_id):
     """
     Logic to get supplier_order_items data
-    
+
     Parameter:
     supplier_order_items_id (int): Id of the supplier_order_items-object
 
@@ -58,23 +58,23 @@ def create_supplier_order_items():
             otherwise an error message
     """
     result = Supplier_order_items.create(order_id=request.values.get('order_id'),
-		ingredient_id=request.values.get('ingredient_id'),
-		qty=request.values.get('qty'),
-		unit_price=request.values.get('unit_price'),
-		received_amount=request.values.get('received_amount'),
-		received=request.values.get('received'),
-		received_at=request.values.get('received_at'),
-		tax_code_id=request.values.get('tax_code_id'))
+        ingredient_id=request.values.get('ingredient_id'),
+        qty=request.values.get('qty'),
+        unit_price=request.values.get('unit_price'),
+        received_amount=request.values.get('received_amount'),
+        received=request.values.get('received'),
+        received_at=request.values.get('received_at'),
+        tax_code_id=request.values.get('tax_code_id'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_order_items_bp.route('/<int:supplier_order_items_id>', methods=['PUT'])
 @jwt_required()
 def update_supplier_order_items(supplier_order_items_id):
     """
     Logic to update supplier_order_items data
-    
+
     Parameter:
         supplier_order_items_id (int): Id of the supplier_order_items-object
 
@@ -87,14 +87,14 @@ def update_supplier_order_items(supplier_order_items_id):
     result = Supplier_order_items.update(supplier_order_items_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_order_items_bp.route('/<int:supplier_order_items_id>', methods=['DELETE'])
 @jwt_required()
 def delete_supplier_order_items(supplier_order_items_id):
     """
     Logic to delete supplier_order_items data
-    
+
     Parameter:
         supplier_order_items_id (int): Id of the supplier_order_items-object
 
@@ -105,4 +105,4 @@ def delete_supplier_order_items(supplier_order_items_id):
     result = Supplier_order_items.delete(supplier_order_items_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/supplier_orders.py
+++ b/app/api/blueprints/supplier_orders.py
@@ -10,19 +10,19 @@ Functions:
 
 Misc variables:
 
-    supplier_orders_id    
+    supplier_orders_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.supplier_orders import Supplier_orders
 
 non_id_columns = ['order_number',
-	'supplier_id',
-	'branch_id',
-	'order_date',
-	'status',
-	'expected_date',
-	'total_amount']
+    'supplier_id',
+    'branch_id',
+    'order_date',
+    'status',
+    'expected_date',
+    'total_amount']
 
 supplier_orders_bp = Blueprint('supplier_orders',
     __name__,
@@ -33,7 +33,7 @@ supplier_orders_bp = Blueprint('supplier_orders',
 def get_supplier_orders(supplier_orders_id):
     """
     Logic to get supplier_orders data
-    
+
     Parameter:
     supplier_orders_id (int): Id of the supplier_orders-object
 
@@ -57,22 +57,22 @@ def create_supplier_orders():
             otherwise an error message
     """
     result = Supplier_orders.create(order_number=request.values.get('order_number'),
-		supplier_id=request.values.get('supplier_id'),
-		branch_id=request.values.get('branch_id'),
-		order_date=request.values.get('order_date'),
-		status=request.values.get('status'),
-		expected_date=request.values.get('expected_date'),
-		total_amount=request.values.get('total_amount'))
+        supplier_id=request.values.get('supplier_id'),
+        branch_id=request.values.get('branch_id'),
+        order_date=request.values.get('order_date'),
+        status=request.values.get('status'),
+        expected_date=request.values.get('expected_date'),
+        total_amount=request.values.get('total_amount'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_orders_bp.route('/<int:supplier_orders_id>', methods=['PUT'])
 @jwt_required()
 def update_supplier_orders(supplier_orders_id):
     """
     Logic to update supplier_orders data
-    
+
     Parameter:
         supplier_orders_id (int): Id of the supplier_orders-object
 
@@ -85,14 +85,14 @@ def update_supplier_orders(supplier_orders_id):
     result = Supplier_orders.update(supplier_orders_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_orders_bp.route('/<int:supplier_orders_id>', methods=['DELETE'])
 @jwt_required()
 def delete_supplier_orders(supplier_orders_id):
     """
     Logic to delete supplier_orders data
-    
+
     Parameter:
         supplier_orders_id (int): Id of the supplier_orders-object
 
@@ -103,4 +103,4 @@ def delete_supplier_orders(supplier_orders_id):
     result = Supplier_orders.delete(supplier_orders_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/supplier_products.py
+++ b/app/api/blueprints/supplier_products.py
@@ -10,18 +10,18 @@ Functions:
 
 Misc variables:
 
-    supplier_products_id    
+    supplier_products_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.supplier_products import Supplier_products
 
 non_id_columns = ['supplier_id',
-	'ingredient_id',
-	'supplier_sku',
-	'purchase_price',
-	'min_order_qty',
-	'lead_time_days']
+    'ingredient_id',
+    'supplier_sku',
+    'purchase_price',
+    'min_order_qty',
+    'lead_time_days']
 
 supplier_products_bp = Blueprint('supplier_products',
     __name__,
@@ -32,7 +32,7 @@ supplier_products_bp = Blueprint('supplier_products',
 def get_supplier_products(supplier_products_id):
     """
     Logic to get supplier_products data
-    
+
     Parameter:
     supplier_products_id (int): Id of the supplier_products-object
 
@@ -56,21 +56,21 @@ def create_supplier_products():
             otherwise an error message
     """
     result = Supplier_products.create(supplier_id=request.values.get('supplier_id'),
-		ingredient_id=request.values.get('ingredient_id'),
-		supplier_sku=request.values.get('supplier_sku'),
-		purchase_price=request.values.get('purchase_price'),
-		min_order_qty=request.values.get('min_order_qty'),
-		lead_time_days=request.values.get('lead_time_days'))
+        ingredient_id=request.values.get('ingredient_id'),
+        supplier_sku=request.values.get('supplier_sku'),
+        purchase_price=request.values.get('purchase_price'),
+        min_order_qty=request.values.get('min_order_qty'),
+        lead_time_days=request.values.get('lead_time_days'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_products_bp.route('/<int:supplier_products_id>', methods=['PUT'])
 @jwt_required()
 def update_supplier_products(supplier_products_id):
     """
     Logic to update supplier_products data
-    
+
     Parameter:
         supplier_products_id (int): Id of the supplier_products-object
 
@@ -83,14 +83,14 @@ def update_supplier_products(supplier_products_id):
     result = Supplier_products.update(supplier_products_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @supplier_products_bp.route('/<int:supplier_products_id>', methods=['DELETE'])
 @jwt_required()
 def delete_supplier_products(supplier_products_id):
     """
     Logic to delete supplier_products data
-    
+
     Parameter:
         supplier_products_id (int): Id of the supplier_products-object
 
@@ -101,4 +101,4 @@ def delete_supplier_products(supplier_products_id):
     result = Supplier_products.delete(supplier_products_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/suppliers.py
+++ b/app/api/blueprints/suppliers.py
@@ -10,22 +10,22 @@ Functions:
 
 Misc variables:
 
-    suppliers_id    
+    suppliers_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.suppliers import Suppliers
 
 non_id_columns = ['name',
-	'contact_name',
-	'email',
-	'phone',
-	'address_line',
-	'postal_code',
-	'city',
-	'country',
-	'created_at',
-	'updated_at']
+    'contact_name',
+    'email',
+    'phone',
+    'address_line',
+    'postal_code',
+    'city',
+    'country',
+    'created_at',
+    'updated_at']
 
 suppliers_bp = Blueprint('suppliers',
     __name__,
@@ -36,7 +36,7 @@ suppliers_bp = Blueprint('suppliers',
 def get_suppliers(suppliers_id):
     """
     Logic to get suppliers data
-    
+
     Parameter:
     suppliers_id (int): Id of the suppliers-object
 
@@ -60,25 +60,25 @@ def create_suppliers():
             otherwise an error message
     """
     result = Suppliers.create(name=request.values.get('name'),
-		contact_name=request.values.get('contact_name'),
-		email=request.values.get('email'),
-		phone=request.values.get('phone'),
-		address_line=request.values.get('address_line'),
-		postal_code=request.values.get('postal_code'),
-		city=request.values.get('city'),
-		country=request.values.get('country'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        contact_name=request.values.get('contact_name'),
+        email=request.values.get('email'),
+        phone=request.values.get('phone'),
+        address_line=request.values.get('address_line'),
+        postal_code=request.values.get('postal_code'),
+        city=request.values.get('city'),
+        country=request.values.get('country'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @suppliers_bp.route('/<int:suppliers_id>', methods=['PUT'])
 @jwt_required()
 def update_suppliers(suppliers_id):
     """
     Logic to update suppliers data
-    
+
     Parameter:
         suppliers_id (int): Id of the suppliers-object
 
@@ -91,14 +91,14 @@ def update_suppliers(suppliers_id):
     result = Suppliers.update(suppliers_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @suppliers_bp.route('/<int:suppliers_id>', methods=['DELETE'])
 @jwt_required()
 def delete_suppliers(suppliers_id):
     """
     Logic to delete suppliers data
-    
+
     Parameter:
         suppliers_id (int): Id of the suppliers-object
 
@@ -109,4 +109,4 @@ def delete_suppliers(suppliers_id):
     result = Suppliers.delete(suppliers_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/tax_codes.py
+++ b/app/api/blueprints/tax_codes.py
@@ -10,16 +10,16 @@ Functions:
 
 Misc variables:
 
-    tax_codes_id    
+    tax_codes_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.tax_codes import Tax_codes
 
 non_id_columns = ['name',
-	'rate',
-	'valid_from',
-	'valid_to']
+    'rate',
+    'valid_from',
+    'valid_to']
 
 tax_codes_bp = Blueprint('tax_codes',
     __name__,
@@ -30,7 +30,7 @@ tax_codes_bp = Blueprint('tax_codes',
 def get_tax_codes(tax_codes_id):
     """
     Logic to get tax_codes data
-    
+
     Parameter:
     tax_codes_id (int): Id of the tax_codes-object
 
@@ -54,19 +54,19 @@ def create_tax_codes():
             otherwise an error message
     """
     result = Tax_codes.create(name=request.values.get('name'),
-		rate=request.values.get('rate'),
-		valid_from=request.values.get('valid_from'),
-		valid_to=request.values.get('valid_to'))
+        rate=request.values.get('rate'),
+        valid_from=request.values.get('valid_from'),
+        valid_to=request.values.get('valid_to'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @tax_codes_bp.route('/<int:tax_codes_id>', methods=['PUT'])
 @jwt_required()
 def update_tax_codes(tax_codes_id):
     """
     Logic to update tax_codes data
-    
+
     Parameter:
         tax_codes_id (int): Id of the tax_codes-object
 
@@ -79,14 +79,14 @@ def update_tax_codes(tax_codes_id):
     result = Tax_codes.update(tax_codes_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @tax_codes_bp.route('/<int:tax_codes_id>', methods=['DELETE'])
 @jwt_required()
 def delete_tax_codes(tax_codes_id):
     """
     Logic to delete tax_codes data
-    
+
     Parameter:
         tax_codes_id (int): Id of the tax_codes-object
 
@@ -97,4 +97,4 @@ def delete_tax_codes(tax_codes_id):
     result = Tax_codes.delete(tax_codes_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/users.py
+++ b/app/api/blueprints/users.py
@@ -10,19 +10,19 @@ Functions:
 
 Misc variables:
 
-    users_id    
+    users_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.users import Users
 
 non_id_columns = ['username',
-	'password_hash',
-	'role_id',
-	'employee_id',
-	'is_active',
-	'created_at',
-	'updated_at']
+    'password_hash',
+    'role_id',
+    'employee_id',
+    'is_active',
+    'created_at',
+    'updated_at']
 
 users_bp = Blueprint('users',
     __name__,
@@ -33,7 +33,7 @@ users_bp = Blueprint('users',
 def get_users(users_id):
     """
     Logic to get users data
-    
+
     Parameter:
     users_id (int): Id of the users-object
 
@@ -57,22 +57,22 @@ def create_users():
             otherwise an error message
     """
     result = Users.create(username=request.values.get('username'),
-		password_hash=request.values.get('password_hash'),
-		role_id=request.values.get('role_id'),
-		employee_id=request.values.get('employee_id'),
-		is_active=request.values.get('is_active'),
-		created_at=request.values.get('created_at'),
-		updated_at=request.values.get('updated_at'))
+        password_hash=request.values.get('password_hash'),
+        role_id=request.values.get('role_id'),
+        employee_id=request.values.get('employee_id'),
+        is_active=request.values.get('is_active'),
+        created_at=request.values.get('created_at'),
+        updated_at=request.values.get('updated_at'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @users_bp.route('/<int:users_id>', methods=['PUT'])
 @jwt_required()
 def update_users(users_id):
     """
     Logic to update users data
-    
+
     Parameter:
         users_id (int): Id of the users-object
 
@@ -85,14 +85,14 @@ def update_users(users_id):
     result = Users.update(users_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @users_bp.route('/<int:users_id>', methods=['DELETE'])
 @jwt_required()
 def delete_users(users_id):
     """
     Logic to delete users data
-    
+
     Parameter:
         users_id (int): Id of the users-object
 
@@ -103,4 +103,4 @@ def delete_users(users_id):
     result = Users.delete(users_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/api/blueprints/warehouses.py
+++ b/app/api/blueprints/warehouses.py
@@ -10,15 +10,15 @@ Functions:
 
 Misc variables:
 
-    warehouses_id    
+    warehouses_id
 """
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from app.db.records.warehouses import Warehouses
 
 non_id_columns = ['branch_id',
-	'name',
-	'description']
+    'name',
+    'description']
 
 warehouses_bp = Blueprint('warehouses',
     __name__,
@@ -29,7 +29,7 @@ warehouses_bp = Blueprint('warehouses',
 def get_warehouses(warehouses_id):
     """
     Logic to get warehouses data
-    
+
     Parameter:
     warehouses_id (int): Id of the warehouses-object
 
@@ -53,18 +53,18 @@ def create_warehouses():
             otherwise an error message
     """
     result = Warehouses.create(branch_id=request.values.get('branch_id'),
-		name=request.values.get('name'),
-		description=request.values.get('description'))
+        name=request.values.get('name'),
+        description=request.values.get('description'))
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @warehouses_bp.route('/<int:warehouses_id>', methods=['PUT'])
 @jwt_required()
 def update_warehouses(warehouses_id):
     """
     Logic to update warehouses data
-    
+
     Parameter:
         warehouses_id (int): Id of the warehouses-object
 
@@ -77,14 +77,14 @@ def update_warehouses(warehouses_id):
     result = Warehouses.update(warehouses_id, **changes)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200
 
 @warehouses_bp.route('/<int:warehouses_id>', methods=['DELETE'])
 @jwt_required()
 def delete_warehouses(warehouses_id):
     """
     Logic to delete warehouses data
-    
+
     Parameter:
         warehouses_id (int): Id of the warehouses-object
 
@@ -95,4 +95,4 @@ def delete_warehouses(warehouses_id):
     result = Warehouses.delete(warehouses_id)
     if result is None:
         return jsonify({'success': False, 'error': 'error when writing data'}), 500
-    return jsonify({'success': True, 'data':result}), 200
+    return jsonify({'success': True, 'data': result}), 200

--- a/app/db/records/accounts.py
+++ b/app/db/records/accounts.py
@@ -1,7 +1,9 @@
 class Accounts:
     table_name = "accounts"
 
-    def __init__(self, id: int = None, name: str = None, account_number: str = None, iban: str = None, bic: str = None, description: str = None):
+    def __init__(self, id: int = None, name: str = None,
+                 account_number: str = None, iban: str = None,
+                 bic: str = None, description: str = None):
         self.id = id
         self.name = name
         self.account_number = account_number

--- a/app/db/records/allergens.py
+++ b/app/db/records/allergens.py
@@ -1,7 +1,8 @@
 class Allergens:
     table_name = "allergens"
 
-    def __init__(self, id: int = None, code: str = None, name: str = None, description: str = None):
+    def __init__(self, id: int = None, code: str = None,
+                 name: str = None, description: str = None):
         self.id = id
         self.code = code
         self.name = name

--- a/app/db/records/branch_opening_hours.py
+++ b/app/db/records/branch_opening_hours.py
@@ -1,7 +1,8 @@
 class Branch_opening_hours:
     table_name = "branch_opening_hours"
 
-    def __init__(self, id: int = None, branch_id: int = None, weekday: int = None, opens: str = None, closes: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 weekday: int = None, opens: str = None, closes: str = None):
         self.id = id
         self.branch_id = branch_id
         self.weekday = weekday

--- a/app/db/records/branch_order_window.py
+++ b/app/db/records/branch_order_window.py
@@ -1,7 +1,9 @@
 class Branch_order_window:
     table_name = "branch_order_window"
 
-    def __init__(self, id: int = None, branch_id: int = None, weekday: int = None, order_start: str = None, order_end: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 weekday: int = None, order_start: str = None,
+                 order_end: str = None):
         self.id = id
         self.branch_id = branch_id
         self.weekday = weekday

--- a/app/db/records/branches.py
+++ b/app/db/records/branches.py
@@ -1,7 +1,11 @@
 class Branches:
     table_name = "branches"
 
-    def __init__(self, id: int = None, name: str = None, address_line: str = None, postal_code: str = None, city: str = None, country: str = None, phone: str = None, email: str = None, opening_note: str = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, name: str = None,
+                 address_line: str = None, postal_code: str = None,
+                 city: str = None, country: str = None, phone: str = None,
+                 email: str = None, opening_note: str = None,
+                 created_at: str = None, updated_at: str = None):
         self.id = id
         self.name = name
         self.address_line = address_line

--- a/app/db/records/complaints.py
+++ b/app/db/records/complaints.py
@@ -1,7 +1,10 @@
 class Complaints:
     table_name = "complaints"
 
-    def __init__(self, id: int = None, customer_id: int = None, order_id: int = None, product_id: int = None, description: str = None, resolved: bool = None, created_at: str = None, resolved_at: str = None):
+    def __init__(self, id: int = None, customer_id: int = None,
+                 order_id: int = None, product_id: int = None,
+                 description: str = None, resolved: bool = None,
+                 created_at: str = None, resolved_at: str = None):
         self.id = id
         self.customer_id = customer_id
         self.order_id = order_id

--- a/app/db/records/customer_feedback.py
+++ b/app/db/records/customer_feedback.py
@@ -1,7 +1,10 @@
 class Customer_feedback:
     table_name = "customer_feedback"
 
-    def __init__(self, id: int = None, customer_id: int = None, branch_id: int = None, order_id: int = None, rating: int = None, comment: str = None, created_at: str = None):
+    def __init__(self, id: int = None, customer_id: int = None,
+                 branch_id: int = None, order_id: int = None,
+                 rating: int = None, comment: str = None,
+                 created_at: str = None):
         self.id = id
         self.customer_id = customer_id
         self.branch_id = branch_id

--- a/app/db/records/customer_order_items.py
+++ b/app/db/records/customer_order_items.py
@@ -1,7 +1,9 @@
 class Customer_order_items:
     table_name = "customer_order_items"
 
-    def __init__(self, id: int = None, order_id: int = None, product_id: int = None, quantity: int = None, unit_price: float = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, order_id: int = None,
+                 product_id: int = None, quantity: int = None,
+                 unit_price: float = None, tax_code_id: int = None):
         self.id = id
         self.order_id = order_id
         self.product_id = product_id

--- a/app/db/records/customer_orders.py
+++ b/app/db/records/customer_orders.py
@@ -1,7 +1,13 @@
 class Customer_orders:
     table_name = "customer_orders"
 
-    def __init__(self, id: int = None, order_number: str = None, customer_id: int = None, customer_name: str = None, branch_id: int = None, order_datetime: str = None, desired_datetime: str = None, serial: str = None, serial_end: str = None, status: str = None, total_amount: float = None, payment_status: str = None, comment: str = None):
+    def __init__(self, id: int = None, order_number: str = None,
+                 customer_id: int = None, customer_name: str = None,
+                 branch_id: int = None, order_datetime: str = None,
+                 desired_datetime: str = None, serial: str = None,
+                 serial_end: str = None, status: str = None,
+                 total_amount: float = None, payment_status: str = None,
+                 comment: str = None):
         self.id = id
         self.order_number = order_number
         self.customer_id = customer_id

--- a/app/db/records/customers.py
+++ b/app/db/records/customers.py
@@ -1,7 +1,13 @@
 class Customers:
     table_name = "customers"
 
-    def __init__(self, id: int = None, type: str = None, company_name: str = None, first_name: str = None, last_name: str = None, email: str = None, phone: str = None, address_line: str = None, postal_code: str = None, city: str = None, country: str = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, type: str = None,
+                 company_name: str = None, first_name: str = None,
+                 last_name: str = None, email: str = None,
+                 phone: str = None, address_line: str = None,
+                 postal_code: str = None, city: str = None,
+                 country: str = None, created_at: str = None,
+                 updated_at: str = None):
         self.id = id
         self.type = type
         self.company_name = company_name

--- a/app/db/records/employee_time_entries.py
+++ b/app/db/records/employee_time_entries.py
@@ -1,7 +1,9 @@
 class Employee_time_entries:
     table_name = "employee_time_entries"
 
-    def __init__(self, id: int = None, employee_id: int = None, branch_id: int = None, clock_in: str = None, clock_out: str = None, break_minutes: int = None):
+    def __init__(self, id: int = None, employee_id: int = None,
+                 branch_id: int = None, clock_in: str = None,
+                 clock_out: str = None, break_minutes: int = None):
         self.id = id
         self.employee_id = employee_id
         self.branch_id = branch_id

--- a/app/db/records/employees.py
+++ b/app/db/records/employees.py
@@ -1,7 +1,12 @@
 class Employees:
     table_name = "employees"
 
-    def __init__(self, id: int = None, first_name: str = None, last_name: str = None, email: str = None, phone: str = None, hire_date: str = None, termination_date: str = None, hourly_wage: float = None, monthly_salary: float = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, first_name: str = None,
+                 last_name: str = None, email: str = None,
+                 phone: str = None, hire_date: str = None,
+                 termination_date: str = None, hourly_wage: float = None,
+                 monthly_salary: float = None, created_at: str = None,
+                 updated_at: str = None):
         self.id = id
         self.first_name = first_name
         self.last_name = last_name

--- a/app/db/records/goods_receipt_items.py
+++ b/app/db/records/goods_receipt_items.py
@@ -1,7 +1,9 @@
 class Goods_receipt_items:
     table_name = "goods_receipt_items"
 
-    def __init__(self, id: int = None, receipt_id: int = None, ingredient_id: int = None, qty: float = None, unit_price: float = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, receipt_id: int = None,
+                 ingredient_id: int = None, qty: float = None,
+                 unit_price: float = None, tax_code_id: int = None):
         self.id = id
         self.receipt_id = receipt_id
         self.ingredient_id = ingredient_id

--- a/app/db/records/goods_receipts.py
+++ b/app/db/records/goods_receipts.py
@@ -1,7 +1,9 @@
 class Goods_receipts:
     table_name = "goods_receipts"
 
-    def __init__(self, id: int = None, receipt_number: str = None, supplier_order_id: int = None, receipt_date: str = None, created_at: str = None):
+    def __init__(self, id: int = None, receipt_number: str = None,
+                 supplier_order_id: int = None, receipt_date: str = None,
+                 created_at: str = None):
         self.id = id
         self.receipt_number = receipt_number
         self.supplier_order_id = supplier_order_id

--- a/app/db/records/ingredients.py
+++ b/app/db/records/ingredients.py
@@ -1,7 +1,10 @@
 class Ingredients:
     table_name = "ingredients"
 
-    def __init__(self, id: int = None, name: str = None, unit: str = None, purchase_price: float = None, tax_code_id: int = None, is_active: bool = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, name: str = None, unit: str = None,
+                 purchase_price: float = None, tax_code_id: int = None,
+                 is_active: bool = None, created_at: str = None,
+                 updated_at: str = None):
         self.id = id
         self.name = name
         self.unit = unit

--- a/app/db/records/inventory_movements.py
+++ b/app/db/records/inventory_movements.py
@@ -1,7 +1,12 @@
 class Inventory_movements:
     table_name = "inventory_movements"
 
-    def __init__(self, id: int = None, movement_type: str = None, ingredient_id: int = None, qty: float = None, unit: str = None, from_location_id: int = None, to_location_id: int = None, reference_type: str = None, reference_id: int = None, created_at: str = None, user_id: int = None):
+    def __init__(self, id: int = None, movement_type: str = None,
+                 ingredient_id: int = None, qty: float = None,
+                 unit: str = None, from_location_id: int = None,
+                 to_location_id: int = None, reference_type: str = None,
+                 reference_id: int = None, created_at: str = None,
+                 user_id: int = None):
         self.id = id
         self.movement_type = movement_type
         self.ingredient_id = ingredient_id

--- a/app/db/records/machines.py
+++ b/app/db/records/machines.py
@@ -1,7 +1,9 @@
 class Machines:
     table_name = "machines"
 
-    def __init__(self, id: int = None, branch_id: int = None, name: str = None, serial_number: str = None, purchase_date: str = None, last_maintenance: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 name: str = None, serial_number: str = None,
+                 purchase_date: str = None, last_maintenance: str = None):
         self.id = id
         self.branch_id = branch_id
         self.name = name

--- a/app/db/records/payment_methods.py
+++ b/app/db/records/payment_methods.py
@@ -1,7 +1,8 @@
 class Payment_methods:
     table_name = "payment_methods"
 
-    def __init__(self, id: int = None, name: str = None, external_code: str = None, is_cash: bool = None):
+    def __init__(self, id: int = None, name: str = None,
+                 external_code: str = None, is_cash: bool = None):
         self.id = id
         self.name = name
         self.external_code = external_code

--- a/app/db/records/payment_transactions.py
+++ b/app/db/records/payment_transactions.py
@@ -1,7 +1,11 @@
 class Payment_transactions:
     table_name = "payment_transactions"
 
-    def __init__(self, id: int = None, account_id: int = None, payment_method_id: int = None, reference_type: str = None, reference_id: int = None, amount: float = None, currency: str = None, direction: str = None, transaction_date: str = None, created_at: str = None):
+    def __init__(self, id: int = None, account_id: int = None,
+                 payment_method_id: int = None, reference_type: str = None,
+                 reference_id: int = None, amount: float = None,
+                 currency: str = None, direction: str = None,
+                 transaction_date: str = None, created_at: str = None):
         self.id = id
         self.account_id = account_id
         self.payment_method_id = payment_method_id

--- a/app/db/records/pos_terminals.py
+++ b/app/db/records/pos_terminals.py
@@ -1,7 +1,9 @@
 class Pos_terminals:
     table_name = "pos_terminals"
 
-    def __init__(self, id: int = None, branch_id: int = None, terminal_code: str = None, description: str = None, is_active: bool = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 terminal_code: str = None, description: str = None,
+                 is_active: bool = None):
         self.id = id
         self.branch_id = branch_id
         self.terminal_code = terminal_code

--- a/app/db/records/production_feedback.py
+++ b/app/db/records/production_feedback.py
@@ -1,7 +1,9 @@
 class Production_feedback:
     table_name = "production_feedback"
 
-    def __init__(self, id: int = None, plan_item_id: int = None, user_id: int = None, produced_qty: float = None, timestamp: str = None):
+    def __init__(self, id: int = None, plan_item_id: int = None,
+                 user_id: int = None, produced_qty: float = None,
+                 timestamp: str = None):
         self.id = id
         self.plan_item_id = plan_item_id
         self.user_id = user_id

--- a/app/db/records/production_plan_items.py
+++ b/app/db/records/production_plan_items.py
@@ -1,7 +1,9 @@
 class Production_plan_items:
     table_name = "production_plan_items"
 
-    def __init__(self, id: int = None, plan_id: int = None, product_id: int = None, planned_qty: float = None, produced_qty: float = None):
+    def __init__(self, id: int = None, plan_id: int = None,
+                 product_id: int = None, planned_qty: float = None,
+                 produced_qty: float = None):
         self.id = id
         self.plan_id = plan_id
         self.product_id = product_id

--- a/app/db/records/production_plans.py
+++ b/app/db/records/production_plans.py
@@ -1,7 +1,9 @@
 class Production_plans:
     table_name = "production_plans"
 
-    def __init__(self, id: int = None, branch_id: int = None, planned_date: str = None, status: str = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 planned_date: str = None, status: str = None,
+                 created_at: str = None, updated_at: str = None):
         self.id = id
         self.branch_id = branch_id
         self.planned_date = planned_date

--- a/app/db/records/products.py
+++ b/app/db/records/products.py
@@ -1,7 +1,10 @@
 class Products:
     table_name = "products"
 
-    def __init__(self, id: int = None, name: str = None, sku: str = None, recipe_id: int = None, sales_price: float = None, tax_code_id: int = None, is_active: bool = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, name: str = None, sku: str = None,
+                 recipe_id: int = None, sales_price: float = None,
+                 tax_code_id: int = None, is_active: bool = None,
+                 created_at: str = None, updated_at: str = None):
         self.id = id
         self.name = name
         self.sku = sku

--- a/app/db/records/recipe_items.py
+++ b/app/db/records/recipe_items.py
@@ -1,7 +1,9 @@
 class Recipe_items:
     table_name = "recipe_items"
 
-    def __init__(self, id: int = None, recipe_id: int = None, ingredient_id: int = None, quantity: float = None, unit: str = None):
+    def __init__(self, id: int = None, recipe_id: int = None,
+                 ingredient_id: int = None, quantity: float = None,
+                 unit: str = None):
         self.id = id
         self.recipe_id = recipe_id
         self.ingredient_id = ingredient_id

--- a/app/db/records/recipes.py
+++ b/app/db/records/recipes.py
@@ -1,7 +1,9 @@
 class Recipes:
     table_name = "recipes"
 
-    def __init__(self, id: int = None, name: str = None, description: str = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, name: str = None,
+                 description: str = None, created_at: str = None,
+                 updated_at: str = None):
         self.id = id
         self.name = name
         self.description = description

--- a/app/db/records/refund_items.py
+++ b/app/db/records/refund_items.py
@@ -1,7 +1,9 @@
 class Refund_items:
     table_name = "refund_items"
 
-    def __init__(self, id: int = None, refund_id: int = None, product_id: int = None, qty: float = None, unit_price: float = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, refund_id: int = None,
+                 product_id: int = None, qty: float = None,
+                 unit_price: float = None, tax_code_id: int = None):
         self.id = id
         self.refund_id = refund_id
         self.product_id = product_id

--- a/app/db/records/refunds.py
+++ b/app/db/records/refunds.py
@@ -1,7 +1,12 @@
 class Refunds:
     table_name = "refunds"
 
-    def __init__(self, id: int = None, receipt_id: int = None, order_id: int = None, refund_datetime: str = None, total_refund_amount: float = None, payment_method_id: int = None, account_id: int = None, reason_id: int = None, created_by: int = None, note: str = None, created_at: str = None):
+    def __init__(self, id: int = None, receipt_id: int = None,
+                 order_id: int = None, refund_datetime: str = None,
+                 total_refund_amount: float = None, payment_method_id: int = None,
+                 account_id: int = None, reason_id: int = None,
+                 created_by: int = None, note: str = None,
+                 created_at: str = None):
         self.id = id
         self.receipt_id = receipt_id
         self.order_id = order_id

--- a/app/db/records/sales_receipt_items.py
+++ b/app/db/records/sales_receipt_items.py
@@ -1,7 +1,9 @@
 class Sales_receipt_items:
     table_name = "sales_receipt_items"
 
-    def __init__(self, id: int = None, receipt_id: int = None, product_id: int = None, qty: float = None, unit_price: float = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, receipt_id: int = None,
+                 product_id: int = None, qty: float = None,
+                 unit_price: float = None, tax_code_id: int = None):
         self.id = id
         self.receipt_id = receipt_id
         self.product_id = product_id

--- a/app/db/records/sales_receipts.py
+++ b/app/db/records/sales_receipts.py
@@ -1,7 +1,11 @@
 class Sales_receipts:
     table_name = "sales_receipts"
 
-    def __init__(self, id: int = None, receipt_number: str = None, branch_id: int = None, pos_terminal_id: int = None, sale_datetime: str = None, customer_id: int = None, total_amount: float = None, payment_method_id: int = None, payment_reference: str = None):
+    def __init__(self, id: int = None, receipt_number: str = None,
+                 branch_id: int = None, pos_terminal_id: int = None,
+                 sale_datetime: str = None, customer_id: int = None,
+                 total_amount: float = None, payment_method_id: int = None,
+                 payment_reference: str = None):
         self.id = id
         self.receipt_number = receipt_number
         self.branch_id = branch_id

--- a/app/db/records/shift_schedule.py
+++ b/app/db/records/shift_schedule.py
@@ -1,7 +1,9 @@
 class Shift_schedule:
     table_name = "shift_schedule"
 
-    def __init__(self, id: int = None, shift_id: int = None, employee_id: int = None, schedule_date: str = None, assigned_hours: float = None):
+    def __init__(self, id: int = None, shift_id: int = None,
+                 employee_id: int = None, schedule_date: str = None,
+                 assigned_hours: float = None):
         self.id = id
         self.shift_id = shift_id
         self.employee_id = employee_id

--- a/app/db/records/shifts.py
+++ b/app/db/records/shifts.py
@@ -1,7 +1,9 @@
 class Shifts:
     table_name = "shifts"
 
-    def __init__(self, id: int = None, branch_id: int = None, name: str = None, start_time: str = None, end_time: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 name: str = None, start_time: str = None,
+                 end_time: str = None):
         self.id = id
         self.branch_id = branch_id
         self.name = name

--- a/app/db/records/supplier_invoice_items.py
+++ b/app/db/records/supplier_invoice_items.py
@@ -1,7 +1,9 @@
 class Supplier_invoice_items:
     table_name = "supplier_invoice_items"
 
-    def __init__(self, id: int = None, invoice_id: int = None, ingredient_id: int = None, qty: float = None, unit_price: float = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, invoice_id: int = None,
+                 ingredient_id: int = None, qty: float = None,
+                 unit_price: float = None, tax_code_id: int = None):
         self.id = id
         self.invoice_id = invoice_id
         self.ingredient_id = ingredient_id

--- a/app/db/records/supplier_invoices.py
+++ b/app/db/records/supplier_invoices.py
@@ -1,7 +1,10 @@
 class Supplier_invoices:
     table_name = "supplier_invoices"
 
-    def __init__(self, id: int = None, invoice_number: str = None, supplier_id: int = None, supplier_order_id: int = None, invoice_date: str = None, due_date: str = None, total_amount: float = None, payment_status: str = None):
+    def __init__(self, id: int = None, invoice_number: str = None,
+                 supplier_id: int = None, supplier_order_id: int = None,
+                 invoice_date: str = None, due_date: str = None,
+                 total_amount: float = None, payment_status: str = None):
         self.id = id
         self.invoice_number = invoice_number
         self.supplier_id = supplier_id

--- a/app/db/records/supplier_order_items.py
+++ b/app/db/records/supplier_order_items.py
@@ -1,7 +1,11 @@
 class Supplier_order_items:
     table_name = "supplier_order_items"
 
-    def __init__(self, id: int = None, order_id: int = None, ingredient_id: int = None, qty: float = None, unit_price: float = None, received_amount: float = None, received: bool = None, received_at: str = None, tax_code_id: int = None):
+    def __init__(self, id: int = None, order_id: int = None,
+                 ingredient_id: int = None, qty: float = None,
+                 unit_price: float = None, received_amount: float = None,
+                 received: bool = None, received_at: str = None,
+                 tax_code_id: int = None):
         self.id = id
         self.order_id = order_id
         self.ingredient_id = ingredient_id

--- a/app/db/records/supplier_orders.py
+++ b/app/db/records/supplier_orders.py
@@ -1,7 +1,10 @@
 class Supplier_orders:
     table_name = "supplier_orders"
 
-    def __init__(self, id: int = None, order_number: str = None, supplier_id: int = None, branch_id: int = None, order_date: str = None, status: str = None, expected_date: str = None, total_amount: float = None):
+    def __init__(self, id: int = None, order_number: str = None,
+                 supplier_id: int = None, branch_id: int = None,
+                 order_date: str = None, status: str = None,
+                 expected_date: str = None, total_amount: float = None):
         self.id = id
         self.order_number = order_number
         self.supplier_id = supplier_id

--- a/app/db/records/supplier_products.py
+++ b/app/db/records/supplier_products.py
@@ -1,7 +1,10 @@
 class Supplier_products:
     table_name = "supplier_products"
 
-    def __init__(self, id: int = None, supplier_id: int = None, ingredient_id: int = None, supplier_sku: str = None, purchase_price: float = None, min_order_qty: float = None, lead_time_days: int = None):
+    def __init__(self, id: int = None, supplier_id: int = None,
+                 ingredient_id: int = None, supplier_sku: str = None,
+                 purchase_price: float = None, min_order_qty: float = None,
+                 lead_time_days: int = None):
         self.id = id
         self.supplier_id = supplier_id
         self.ingredient_id = ingredient_id

--- a/app/db/records/suppliers.py
+++ b/app/db/records/suppliers.py
@@ -1,7 +1,12 @@
 class Suppliers:
     table_name = "suppliers"
 
-    def __init__(self, id: int = None, name: str = None, contact_name: str = None, email: str = None, phone: str = None, address_line: str = None, postal_code: str = None, city: str = None, country: str = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, name: str = None,
+                 contact_name: str = None, email: str = None,
+                 phone: str = None, address_line: str = None,
+                 postal_code: str = None, city: str = None,
+                 country: str = None, created_at: str = None,
+                 updated_at: str = None):
         self.id = id
         self.name = name
         self.contact_name = contact_name

--- a/app/db/records/tax_codes.py
+++ b/app/db/records/tax_codes.py
@@ -1,7 +1,8 @@
 class Tax_codes:
     table_name = "tax_codes"
 
-    def __init__(self, id: int = None, name: str = None, rate: float = None, valid_from: str = None, valid_to: str = None):
+    def __init__(self, id: int = None, name: str = None, rate: float = None,
+                 valid_from: str = None, valid_to: str = None):
         self.id = id
         self.name = name
         self.rate = rate

--- a/app/db/records/users.py
+++ b/app/db/records/users.py
@@ -1,7 +1,10 @@
 class Users:
     table_name = "users"
 
-    def __init__(self, id: int = None, username: str = None, password_hash: str = None, role_id: int = None, employee_id: int = None, is_active: bool = None, created_at: str = None, updated_at: str = None):
+    def __init__(self, id: int = None, username: str = None,
+                 password_hash: str = None, role_id: int = None,
+                 employee_id: int = None, is_active: bool = None,
+                 created_at: str = None, updated_at: str = None):
         self.id = id
         self.username = username
         self.password_hash = password_hash
@@ -13,5 +16,8 @@ class Users:
 
     def to_dict(self):
         return {
-            "id": self.id, "username": self.username, "password_hash": self.password_hash, "role_id": self.role_id, "employee_id": self.employee_id, "is_active": self.is_active, "created_at": self.created_at, "updated_at": self.updated_at
+            "id": self.id, "username": self.username,
+            "password_hash": self.password_hash, "role_id": self.role_id,
+            "employee_id": self.employee_id, "is_active": self.is_active,
+            "created_at": self.created_at, "updated_at": self.updated_at
         }

--- a/app/db/records/warehouses.py
+++ b/app/db/records/warehouses.py
@@ -1,7 +1,8 @@
 class Warehouses:
     table_name = "warehouses"
 
-    def __init__(self, id: int = None, branch_id: int = None, name: str = None, description: str = None):
+    def __init__(self, id: int = None, branch_id: int = None,
+                 name: str = None, description: str = None):
         self.id = id
         self.branch_id = branch_id
         self.name = name

--- a/generators/create_api.py
+++ b/generators/create_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from create_db import get_table_names, get_columns_for_table
 from environment_constants import API_BLUEPRINTS_PATH
 
+
 def generate():
     """
     Main function for generating the app/api/blueprint files.
@@ -15,6 +16,7 @@ def generate():
         output_path.parent.mkdir(exist_ok=True, parents=True)
         with open(output_path, "w") as f:
             f.write(generate_routes_file_for_table(table))
+
 
 def generate_routes_file_for_table(table):
     """
@@ -81,7 +83,8 @@ def create_{table}():
         json-structure: Returns status code and if operation succeeded the returned data
             otherwise an error message
     \"\"\"
-    result = {table.capitalize()}.create({f',{new_line}{tab}{tab}'.join([f"{col[0]}=request.values.get('{col[0]}')" for col in non_id_columns])})
+    result = {table.capitalize()}.create(
+        {f',{new_line}{tab}{tab}'.join([f"{col[0]}=request.values.get('{col[0]}')" for col in non_id_columns])})
     if result is None:
         return jsonify({{'success': False, 'error': 'error when writing data'}}), 500
     return jsonify({{'success': True, 'data':result}}), 200
@@ -91,7 +94,7 @@ def create_{table}():
 def update_{table}({table}_id):
     \"\"\"
     Logic to update {table} data
-    
+
     Parameter:
         {table}_id (int): Id of the {table}-object
 
@@ -110,7 +113,7 @@ def update_{table}({table}_id):
 def delete_{table}({table}_id):
     \"\"\"
     Logic to delete {table} data
-    
+
     Parameter:
         {table}_id (int): Id of the {table}-object
 
@@ -125,6 +128,7 @@ def delete_{table}({table}_id):
 """
     return code
 
+
 def get_changes_line():
     """
     Returns the line number where changes happened
@@ -134,6 +138,7 @@ def get_changes_line():
     """
     return """changes = {f'{col[0]}': request.values.get(f'{col[0]}')
         for col in non_id_columns if request.values.get(f'{col[0]}') is not None}"""
+
 
 if __name__ == "__main__":
     generate()

--- a/generators/create_db.py
+++ b/generators/create_db.py
@@ -20,11 +20,12 @@ import sys
 import os
 
 # Allow imports when running script from within the project directory
-[sys.path.append(i) for i in ['.', '..']]  #pylint: disable=expression-not-assigned
+[sys.path.append(i) for i in ['.', '..']]  # pylint: disable=expression-not-assigned
 
 from app.db.db_connection import connect  # pylint: disable=wrong-import-position
 
 OUTPUT_DIR = "../app/db/records"  # Specify the directory to store the generated files
+
 
 def get_table_names():
     """
@@ -48,6 +49,7 @@ def get_table_names():
         tables = [row[0] for row in cur.fetchall()]
     conn.close()
     return tables
+
 
 def get_columns_for_table(table_name):
     """
@@ -75,6 +77,7 @@ def get_columns_for_table(table_name):
         columns = cur.fetchall()
     conn.close()
     return columns
+
 
 def generate_crud_class(table_name, columns):
     """
@@ -146,6 +149,7 @@ def generate_crud_class(table_name, columns):
 """
     return code
 
+
 def main():
     """
     Main execution function for this script.
@@ -161,6 +165,7 @@ def main():
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(crud_code)
     print(f"CRUD classes have been written to `{OUTPUT_DIR}`.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/api_blueprints/test_users.py
+++ b/tests/api_blueprints/test_users.py
@@ -1,10 +1,11 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-
 import pytest
 from flask import Flask
-from api_blueprints.users import users_bp
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+from app.api.blueprints.users import users_bp
+
 
 @pytest.fixture
 def app():
@@ -17,9 +18,11 @@ def app():
     JWTManager(app)
     yield app
 
+
 @pytest.fixture
 def client(app):
     return app.test_client()
+
 
 @pytest.fixture
 def auth_header(app):
@@ -27,6 +30,7 @@ def auth_header(app):
     with app.app_context():
         token = create_access_token(identity="1")
         return {'Authorization': f'Bearer {token}'}
+
 
 class TestUsersAPI:
     def test_get_users_success(self, client, auth_header, mocker):
@@ -43,7 +47,9 @@ class TestUsersAPI:
 
     def test_create_users_success(self, client, auth_header, mocker):
         mocker.patch('db.Users.create', return_value={'id': 1, 'username': 'test'})
-        data = {'username': 'test', 'password_hash': 'pw', 'role_id': 1, 'employee_id': 1, 'is_active': True, 'created_at': '2024-01-01', 'updated_at': '2024-01-01'}
+        data = {'username': 'test', 'password_hash': 'pw', 'role_id': 1,
+                'employee_id': 1, 'is_active': True, 'created_at': '2024-01-01',
+                'updated_at': '2024-01-01'}
         resp = client.post('/users/', data=data, headers=auth_header)
         assert resp.status_code == 200
         assert resp.json['success'] is True


### PR DESCRIPTION
# Fix build issues in PR #8

## Summary

This PR addresses the build failures in PR #8 by fixing the primary import error and resolving numerous flake8 linting violations across the codebase.

**Key Changes:**
- **Fixed critical import error** in `tests/api_blueprints/test_users.py` - changed incorrect import path from `api_blueprints.users` to `app.api.blueprints.users`
- **Extensive linting fixes** across 90 files including:
  - Line length violations (broke long parameter lists and dictionary definitions into multiple lines)
  - Mixed indentation issues (replaced tabs with spaces throughout blueprint files)
  - Missing whitespace after colons in JSON responses
  - Trailing whitespace removal
  - Missing blank lines before function definitions
  - Import order corrections in generator files

**Files Modified:** 90 files with 941 insertions and 807 deletions

## Review & Testing Checklist for Human

⚠️ **HIGH RISK**: This PR includes extensive automated formatting changes across 90 files

- [ ] **Verify CI passes completely** - Check that both pytest and flake8 checks now pass in the CI pipeline
- [ ] **Run full test suite locally** - Ensure no functionality was broken by the bulk formatting changes
- [ ] **Spot-check heavily modified files** - Review a sample of blueprint files (e.g., `users.py`, `accounts.py`) to ensure automated edits didn't introduce syntax errors
- [ ] **Test the import fix** - Verify that `tests/api_blueprints/test_users.py` can now import correctly from `app.api.blueprints.users`
- [ ] **End-to-end functionality test** - Test actual API endpoints to ensure the formatting changes didn't break runtime behavior

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    TestFile["tests/api_blueprints/<br/>test_users.py"]:::major-edit
    UsersBlueprint["app/api/blueprints/<br/>users.py"]:::major-edit
    AllBlueprints["app/api/blueprints/<br/>(46 blueprint files)"]:::major-edit
    RecordsFiles["app/db/records/<br/>(40 record files)"]:::major-edit
    GeneratorAPI["generators/<br/>create_api.py"]:::minor-edit
    GeneratorDB["generators/<br/>create_db.py"]:::minor-edit
    
    TestFile -->|"imports users_bp from"| UsersBlueprint
    GeneratorAPI -->|"generates"| AllBlueprints
    GeneratorDB -->|"generates"| RecordsFiles
    AllBlueprints -->|"uses models from"| RecordsFiles
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Original Issue**: PR #8 was failing CI due to `ModuleNotFoundError: No module named 'api_blueprints'` and 1907 flake8 violations
- **Remaining Work**: After these fixes, there are still 746 flake8 violations remaining, but the critical import error is resolved
- **Testing Limitation**: Local pytest testing was limited due to missing database dependencies in the development environment
- **Session Details**: Requested by Alex Trautmann (@notrautmann) - [Devin Session](https://app.devin.ai/sessions/5216671abc704564aa6314ecc71197f9)

**⚠️ Important**: Due to the extensive scope of automated changes, thorough testing is essential before merging to ensure no functionality was inadvertently broken.